### PR TITLE
Reading client version from pom.xml instead of clientConstants

### DIFF
--- a/azure-servicebus/pom.xml
+++ b/azure-servicebus/pom.xml
@@ -5,14 +5,20 @@
 	<artifactId>azure-servicebus</artifactId>	
 	<version>${client-current-version}</version>
 	<url>https://github.com/Azure/azure-service-bus-java</url>
-	
+
 	<parent>
 		<groupId>com.microsoft.azure</groupId>
 		<artifactId>azure-servicebus-parent</artifactId>
 		<version>1.0.0-RC</version>
 	</parent>
-	
+
 	<build>
+		<resources>
+			<resource>
+				<directory>resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -30,7 +36,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 	        	<artifactId>maven-surefire-plugin</artifactId>
 	        	<version>2.20</version>
-	      </plugin>
+	      	</plugin>
 		</plugins>
 	</build>
 

--- a/azure-servicebus/resources/client.properties
+++ b/azure-servicebus/resources/client.properties
@@ -1,0 +1,1 @@
+client.version = ${project.version}

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientConstants.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientConstants.java
@@ -4,7 +4,9 @@
  */
 package com.microsoft.azure.servicebus.primitives;
 
+import java.io.IOException;
 import java.time.*;
+import java.util.Properties;
 import java.util.UUID;
 
 import org.apache.qpid.proton.amqp.*;
@@ -17,7 +19,7 @@ public final class ClientConstants
 	
 	public static final String FATAL_MARKER = "FATAL";
 	public final static String PRODUCT_NAME = "MSJavaClient";
-    public final static String CURRENT_JAVACLIENT_VERSION = "0.13.1";
+    public final static String CURRENT_JAVACLIENT_VERSION =  getClientVersion();
     public static final String PLATFORM_INFO = getPlatformInfo();
     
 	public static final int LOCKTOKENSIZE = 16;
@@ -166,7 +168,19 @@ public final class ClientConstants
     static final int DEFAULT_SAS_TOKEN_VALIDITY_IN_SECONDS = 20*60; // 20 minutes
     static final int DEFAULT_SAS_TOKEN_SEND_RETRY_INTERVAL_IN_SECONDS = 5;
     static final String SAS_TOKEN_AUDIENCE_FORMAT = "amqp://%s/%s";
-    
+
+    private static String getClientVersion() {
+        String clientVersion = "";
+        final Properties properties = new Properties();
+        try {
+            properties.load(ClientConstants.class.getResourceAsStream("/client.properties"));
+            clientVersion = properties.getProperty("client.version");
+        } catch (IOException e) {
+        }
+
+        return clientVersion;
+    }
+
     private static String getPlatformInfo() {
         final Package javaRuntimeClassPkg = Runtime.class.getPackage();
         final StringBuilder patformInfo = new StringBuilder();

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientConstants.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientConstants.java
@@ -12,11 +12,15 @@ import java.util.UUID;
 import org.apache.qpid.proton.amqp.*;
 
 import com.microsoft.azure.servicebus.amqp.AmqpConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ClientConstants
 {
 	private ClientConstants() { }
-	
+
+    private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(ClientConstants.class);
+
 	public static final String FATAL_MARKER = "FATAL";
 	public final static String PRODUCT_NAME = "MSJavaClient";
     public final static String CURRENT_JAVACLIENT_VERSION =  getClientVersion();
@@ -170,12 +174,14 @@ public final class ClientConstants
     static final String SAS_TOKEN_AUDIENCE_FORMAT = "amqp://%s/%s";
 
     private static String getClientVersion() {
-        String clientVersion = "";
+        String clientVersion;
         final Properties properties = new Properties();
         try {
             properties.load(ClientConstants.class.getResourceAsStream("/client.properties"));
             clientVersion = properties.getProperty("client.version");
         } catch (IOException e) {
+            clientVersion = "NOTFOUND";
+            TRACE_LOGGER.error("Exception while retrieving client version. Exception: ", e.toString());
         }
 
         return clientVersion;


### PR DESCRIPTION
## Description
While opening AMQP connection, the java client version being sent was read from a ClientConstants file which needs to be updated every time we update the pom.xml. Instead now, moved it to resources so that the code automatically reads the version from pom.xml 

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.