### PR TITLE
Making a semantic change to queue client, subscription client setPref…

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
@@ -471,7 +471,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 		if(deltaPrefetchCount > 0)
 		{
 		    try
-	        {	            
+	        {
 	            this.underlyingFactory.scheduleOnReactorThread(new DispatchHandler()
 	            {
 	                @Override


### PR DESCRIPTION
…etchCount so prefetch count can be set even without register a handler. (#107)

* Fixing javadoc generation errors

* Adding dependency to use SLF4J logging instead of java util logging.

* More SLF4J migration

* Changed all java util logging statements to slf4j.

* Checking in the POM that goes with the release to maven reposisory.

* Removed unused imports

* Instrumented all code with SLF4J logging.

* Fixing some log statements

* Moving request-response link creation to message factory so we don't create multiple links to the same entity.

* Updaing third party notice to include SLF4J license.

* Updating distributed POM

* Renaming setContent method to setBody.

* Fixing a typo in log statement.

* Handling the special case of 0 timeout for receives. If there are no prefetched messages, receive call returns immediately with already prefetched messages.

* Correcting a log statement

* Added javadoc comments for rules package.

* Adding javadoc comments. Work in progress.

* More javadoc comments added.

* Fixing a minor bug in sender and receiver creation. Closes the messaging factory if sender or receiver creation fails.

* Fixing the issue of not renewing CBS tokens. Also a concurrency fix.

* Fixing a bug in session receiver to not repeatedly attempt accepting the same session on lock lost.

* Added some java docs.. And changed default prefetch count, based on receive mode.

* Fixing a thread unending wait bug in request-response link.

* Fixing AuthorizationFailed exceptions that pop when the conncetion is recreated.

* Minor tweaks

* Another minor fix

* More minor bug fixes and tweaks

* Changing version to 1.0.0-RC-1

* Fixing some concurrency issues, performance improvements and refactoring.

* Minor fix in receiver

* Changing return messages loop interval to 100 milliseconds

* Changing zero timeout approximation to 200 milliseconds

* Changing zero timeout approximation to 200 milliseconds. Also improving tracing to better identify stress issues.

* Adding more info to a trace

* Changing default prefetch count to 0 in peeklock mode as well.

* Fixing a bug in setPrefetchCount

* Chagning version number to 1.0.0

* Making a semantic change to queue client, subscription client setPrefetchCount so prefetch count can be set even without register a handler.

## Description
<!--
Please add an informative description that covers the changes made by the pull request.

If applicable, reference the bug/issue that this pull request fixes here.
-->

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.