### PR TITLE
Updating visibility of static ClientFactory methods for use outside of azure packages

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/ClientFactory.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/ClientFactory.java
@@ -253,11 +253,11 @@ public final class ClientFactory {
         return Utils.completeFuture(acceptSessionFromConnectionStringBuilderAsync(amqpConnectionStringBuilder, sessionId, receiveMode));
     }
 
-    static IMessageSession acceptSessionFromEntityPath(MessagingFactory messagingFactory, String entityPath, String sessionId) throws InterruptedException, ServiceBusException {
+    public static IMessageSession acceptSessionFromEntityPath(MessagingFactory messagingFactory, String entityPath, String sessionId) throws InterruptedException, ServiceBusException {
         return acceptSessionFromEntityPath(messagingFactory, entityPath, sessionId, DEFAULTRECEIVEMODE);
     }
 
-    static IMessageSession acceptSessionFromEntityPath(MessagingFactory messagingFactory, String entityPath, String sessionId, ReceiveMode receiveMode) throws InterruptedException, ServiceBusException {
+    public static IMessageSession acceptSessionFromEntityPath(MessagingFactory messagingFactory, String entityPath, String sessionId, ReceiveMode receiveMode) throws InterruptedException, ServiceBusException {
         return Utils.completeFuture(acceptSessionFromEntityPathAsync(messagingFactory, entityPath, sessionId, receiveMode));
     }
 

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/ClientFactory.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/ClientFactory.java
@@ -46,7 +46,7 @@ public final class ClientFactory {
         return Utils.completeFuture(createMessageSenderFromConnectionStringBuilderAsync(amqpConnectionStringBuilder));
     }
 
-    static IMessageSender createMessageSenderFromEntityPath(MessagingFactory messagingFactory, String entityPath) throws InterruptedException, ServiceBusException {
+    public static IMessageSender createMessageSenderFromEntityPath(MessagingFactory messagingFactory, String entityPath) throws InterruptedException, ServiceBusException {
         return Utils.completeFuture(createMessageSenderFromEntityPathAsync(messagingFactory, entityPath));
     }
 
@@ -73,7 +73,7 @@ public final class ClientFactory {
         return sender.initializeAsync().thenApply((v) -> sender);
     }
 
-    static CompletableFuture<IMessageSender> createMessageSenderFromEntityPathAsync(MessagingFactory messagingFactory, String entityPath) {
+    public static CompletableFuture<IMessageSender> createMessageSenderFromEntityPathAsync(MessagingFactory messagingFactory, String entityPath) {
         Utils.assertNonNull("messagingFactory", messagingFactory);
         MessageSender sender = new MessageSender(messagingFactory, entityPath);
         return sender.initializeAsync().thenApply((v) -> sender);
@@ -136,11 +136,11 @@ public final class ClientFactory {
         return Utils.completeFuture(createMessageReceiverFromConnectionStringBuilderAsync(amqpConnectionStringBuilder, receiveMode));
     }
 
-    static IMessageReceiver createMessageReceiverFromEntityPath(MessagingFactory messagingFactory, String entityPath) throws InterruptedException, ServiceBusException {
+    public static IMessageReceiver createMessageReceiverFromEntityPath(MessagingFactory messagingFactory, String entityPath) throws InterruptedException, ServiceBusException {
         return createMessageReceiverFromEntityPath(messagingFactory, entityPath, DEFAULTRECEIVEMODE);
     }
 
-    static IMessageReceiver createMessageReceiverFromEntityPath(MessagingFactory messagingFactory, String entityPath, ReceiveMode receiveMode) throws InterruptedException, ServiceBusException {
+    public static IMessageReceiver createMessageReceiverFromEntityPath(MessagingFactory messagingFactory, String entityPath, ReceiveMode receiveMode) throws InterruptedException, ServiceBusException {
         return Utils.completeFuture(createMessageReceiverFromEntityPathAsync(messagingFactory, entityPath, receiveMode));
     }
 


### PR DESCRIPTION
## Description
The current visibility of of non-public static methods does not allow use outside of azure packages.
However the Tests written are using these static methods to demonstrate the features. 
The PR updates the visibility of all the static methods in ClientFactory which are used in the Tests written in this library.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ✓] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ✓] Title of the pull request is clear and informative.
- [ ✓] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [✓ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [✓ ] If applicable, the public code is properly documented.
- [✓] Pull request includes test coverage for the included changes.
- [✓] The code builds without any errors.


This PR resolves many issues similar to the below:
![visibility error-2017-08-17_12-45-56](https://user-images.githubusercontent.com/646649/29425768-0f3b84de-834a-11e7-8a7a-df1537474c69.png)
