### PR TITLE
Fix to allow creation of QueueClient with a listen only SAS key

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/QueueClient.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/QueueClient.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
+import com.microsoft.azure.servicebus.primitives.ExceptionUtil;
 import com.microsoft.azure.servicebus.primitives.MessagingFactory;
 import com.microsoft.azure.servicebus.primitives.MiscRequestResponseOperationHandler;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
@@ -22,19 +23,25 @@ import com.microsoft.azure.servicebus.primitives.StringUtil;
 public final class QueueClient extends InitializableEntity implements IQueueClient {
     private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(QueueClient.class);
     private final ReceiveMode receiveMode;
+    private final String queuePath;
+    private final Object senderCreationLock;
     private MessagingFactory factory;
     private IMessageSender sender;
+    private CompletableFuture<Void> senderCreationFuture;
+    
     private MessageAndSessionPump messageAndSessionPump;
     private SessionBrowser sessionBrowser;
     private MiscRequestResponseOperationHandler miscRequestResponseHandler;
 
-    private QueueClient(ReceiveMode receiveMode) {
+    private QueueClient(ReceiveMode receiveMode, String queuePath) {
         super(StringUtil.getShortRandomString(), null);
         this.receiveMode = receiveMode;
+        this.queuePath = queuePath;
+        this.senderCreationLock = new Object();
     }
 
     public QueueClient(ConnectionStringBuilder amqpConnectionStringBuilder, ReceiveMode receiveMode) throws InterruptedException, ServiceBusException {
-        this(receiveMode);
+        this(receiveMode, amqpConnectionStringBuilder.getEntityPath());
         CompletableFuture<MessagingFactory> factoryFuture = MessagingFactory.createFromConnectionStringBuilderAsync(amqpConnectionStringBuilder);
         Utils.completeFuture(factoryFuture.thenComposeAsync((f) -> this.createInternals(f, amqpConnectionStringBuilder.getEntityPath(), receiveMode)));
         if (TRACE_LOGGER.isInfoEnabled()) {
@@ -43,7 +50,7 @@ public final class QueueClient extends InitializableEntity implements IQueueClie
     }
 
     QueueClient(MessagingFactory factory, String queuePath, ReceiveMode receiveMode) throws InterruptedException, ServiceBusException {
-        this(receiveMode);
+        this(receiveMode, queuePath);
         Utils.completeFuture(this.createInternals(factory, queuePath, receiveMode));
         if (TRACE_LOGGER.isInfoEnabled()) {
             TRACE_LOGGER.info("Created queue client to queue '{}'", queuePath);
@@ -52,10 +59,6 @@ public final class QueueClient extends InitializableEntity implements IQueueClie
 
     private CompletableFuture<Void> createInternals(MessagingFactory factory, String queuePath, ReceiveMode receiveMode) {
         this.factory = factory;
-        CompletableFuture<IMessageSender> senderFuture = ClientFactory.createMessageSenderFromEntityPathAsync(factory, queuePath);
-        CompletableFuture<Void> postSenderFuture = senderFuture.thenAcceptAsync((s) -> {
-            this.sender = s;
-        });
 
         CompletableFuture<Void> postSessionBrowserFuture = MiscRequestResponseOperationHandler.create(factory, queuePath).thenAcceptAsync((msoh) -> {
             this.miscRequestResponseHandler = msoh;
@@ -65,7 +68,69 @@ public final class QueueClient extends InitializableEntity implements IQueueClie
         this.messageAndSessionPump = new MessageAndSessionPump(factory, queuePath, receiveMode);
         CompletableFuture<Void> messagePumpInitFuture = this.messageAndSessionPump.initializeAsync();
 
-        return CompletableFuture.allOf(postSenderFuture, postSessionBrowserFuture, messagePumpInitFuture);
+        return CompletableFuture.allOf(postSessionBrowserFuture, messagePumpInitFuture);
+    }
+    
+    private CompletableFuture<Void> createSenderAsync()
+    {
+        synchronized (this.senderCreationLock) {
+            if(this.senderCreationFuture == null)
+            {
+                this.senderCreationFuture = new CompletableFuture<Void>();
+                ClientFactory.createMessageSenderFromEntityPathAsync(this.factory, this.queuePath).handleAsync((sender, ex) ->
+                {
+                    if(ex == null)
+                    {
+                        this.sender = sender;
+                        this.senderCreationFuture.complete(null);
+                    }
+                    else
+                    {
+                        Throwable cause = ExceptionUtil.extractAsyncCompletionCause(ex);
+                        this.senderCreationFuture.completeExceptionally(cause);
+                        // Set it to null so next call will retry sender creation
+                        synchronized (this.senderCreationLock)
+                        {
+                            this.senderCreationFuture = null;
+                        }
+                    }
+                    return null;
+                });
+            }
+            
+            return this.senderCreationFuture;
+        }
+    }
+    
+    private CompletableFuture<Void> closeSenderAsync()
+    {
+        if(this.sender != null)
+        {
+            synchronized (this.senderCreationLock)
+            {
+                this.senderCreationFuture = null;
+            }
+            
+            return this.sender.closeAsync();
+        }
+        else
+        {
+            synchronized (this.senderCreationLock)
+            {
+                if(this.senderCreationFuture != null)
+                {
+                    this.senderCreationFuture = null;
+                    
+                    return this.senderCreationFuture.thenComposeAsync((v) -> {
+                        return this.sender.closeAsync();
+                    });
+                }
+                else
+                {
+                    return CompletableFuture.completedFuture(null);
+                }
+            }
+        }
     }
 
     @Override
@@ -75,47 +140,59 @@ public final class QueueClient extends InitializableEntity implements IQueueClie
 
     @Override
     public void send(IMessage message) throws InterruptedException, ServiceBusException {
-        this.sender.send(message);
+        Utils.completeFuture(this.sendAsync(message));
     }
 
     @Override
     public void sendBatch(Collection<? extends IMessage> messages) throws InterruptedException, ServiceBusException {
-        this.sender.sendBatch(messages);
+        Utils.completeFuture(this.sendBatchAsync(messages));
     }
 
     @Override
     public CompletableFuture<Void> sendAsync(IMessage message) {
-        return this.sender.sendAsync(message);
+        return this.createSenderAsync().thenComposeAsync((v) -> 
+        {
+            return this.sender.sendAsync(message);
+        });
     }
 
     @Override
     public CompletableFuture<Void> sendBatchAsync(Collection<? extends IMessage> messages) {
-        return this.sender.sendBatchAsync(messages);
+        return this.createSenderAsync().thenComposeAsync((v) -> 
+        {
+            return this.sender.sendBatchAsync(messages);
+        });
     }
 
     @Override
     public CompletableFuture<Long> scheduleMessageAsync(IMessage message, Instant scheduledEnqueueTimeUtc) {
-        return this.sender.scheduleMessageAsync(message, scheduledEnqueueTimeUtc);
+        return this.createSenderAsync().thenComposeAsync((v) -> 
+        {
+            return this.sender.scheduleMessageAsync(message, scheduledEnqueueTimeUtc);
+        });
     }
 
     @Override
     public CompletableFuture<Void> cancelScheduledMessageAsync(long sequenceNumber) {
-        return this.sender.cancelScheduledMessageAsync(sequenceNumber);
+        return this.createSenderAsync().thenComposeAsync((v) -> 
+        {
+            return this.sender.cancelScheduledMessageAsync(sequenceNumber);
+        });
     }
 
     @Override
     public long scheduleMessage(IMessage message, Instant scheduledEnqueueTimeUtc) throws InterruptedException, ServiceBusException {
-        return this.sender.scheduleMessage(message, scheduledEnqueueTimeUtc);
+        return Utils.completeFuture(this.scheduleMessageAsync(message, scheduledEnqueueTimeUtc));
     }
 
     @Override
     public void cancelScheduledMessage(long sequenceNumber) throws InterruptedException, ServiceBusException {
-        this.sender.cancelScheduledMessage(sequenceNumber);
+        Utils.completeFuture(this.cancelScheduledMessageAsync(sequenceNumber));
     }
 
     @Override
     public String getEntityPath() {
-        return this.sender.getEntityPath();
+        return this.queuePath;
     }
 
     @Override
@@ -146,7 +223,7 @@ public final class QueueClient extends InitializableEntity implements IQueueClie
 
     @Override
     protected CompletableFuture<Void> onClose() {
-        return this.messageAndSessionPump.closeAsync().thenCompose((v) -> this.sender.closeAsync().thenCompose((u) -> this.miscRequestResponseHandler.closeAsync().thenCompose((w) -> this.factory.closeAsync())));
+        return this.messageAndSessionPump.closeAsync().thenCompose((v) -> this.closeSenderAsync().thenCompose((u) -> this.miscRequestResponseHandler.closeAsync().thenCompose((w) -> this.factory.closeAsync())));
     }
 
     //	@Override

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/SubscriptionClient.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/SubscriptionClient.java
@@ -26,7 +26,7 @@ public final class SubscriptionClient extends InitializableEntity implements ISu
     private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(SubscriptionClient.class);
     private static final String SUBSCRIPTIONS_DELIMITER = "/subscriptions/";
 	private final ReceiveMode receiveMode;
-	private String subscriptionPath;
+	private final String subscriptionPath;
 	private MessagingFactory factory;
 	private MessageAndSessionPump messageAndSessionPump;
 	private SessionBrowser sessionBrowser;
@@ -34,16 +34,16 @@ public final class SubscriptionClient extends InitializableEntity implements ISu
 
 	public static final String DEFAULT_RULE_NAME = "$Default";
 
-	private SubscriptionClient(ReceiveMode receiveMode)
+	private SubscriptionClient(ReceiveMode receiveMode, String subscriptionPath)
 	{
 		super(StringUtil.getShortRandomString(), null);		
 		this.receiveMode = receiveMode;
+		this.subscriptionPath = subscriptionPath;
 	}
 	
 	public SubscriptionClient(ConnectionStringBuilder amqpConnectionStringBuilder, ReceiveMode receiveMode) throws InterruptedException, ServiceBusException
 	{
-		this(receiveMode);		
-		this.subscriptionPath = amqpConnectionStringBuilder.getEntityPath();
+		this(receiveMode, amqpConnectionStringBuilder.getEntityPath());
 		CompletableFuture<MessagingFactory> factoryFuture = MessagingFactory.createFromConnectionStringBuilderAsync(amqpConnectionStringBuilder);
 		Utils.completeFuture(factoryFuture.thenComposeAsync((f) -> this.createPumpAndBrowserAsync(f)));
 		if(TRACE_LOGGER.isInfoEnabled())
@@ -54,8 +54,7 @@ public final class SubscriptionClient extends InitializableEntity implements ISu
 	
 	SubscriptionClient(MessagingFactory factory, String subscriptionPath, ReceiveMode receiveMode) throws InterruptedException, ServiceBusException
 	{
-		this(receiveMode);
-		this.subscriptionPath = subscriptionPath;
+		this(receiveMode, subscriptionPath);
 		Utils.completeFuture(this.createPumpAndBrowserAsync(factory));
 		TRACE_LOGGER.info("Created subscription client to subscripton '{}'", subscriptionPath);
 	}


### PR DESCRIPTION
If some application wants to use a QueueClient only to receive messages, it can create a queue client with a SAS key that has listen only permissions. This fix allows that creation, by not creating a sender in the constructor.