### PR TITLE
Changing the type of message properties

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/IMessage.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/IMessage.java
@@ -206,7 +206,7 @@ public interface IMessage {
      * @return the map of user application properties of this message
      * @see <a href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads">Messages, payloads, and serialization</a>
      */
-    public Map<String, String> getProperties();
+    public Map<String, Object> getProperties();
 
     /**
      * Sets the map of user application properties of this message. Client applications 
@@ -215,7 +215,7 @@ public interface IMessage {
      * @param properties the map of user application properties of this message
      * @see #getProperties()
      */
-    void setProperties(Map<String, String> properties);
+    void setProperties(Map<String, Object> properties);
 
     /**
      * Gets a correlation identifier.

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/Message.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/Message.java
@@ -44,7 +44,7 @@ final public class Message implements Serializable, IMessage {
 	
 	private Instant lockedUntilUtc;
 	
-	private Map<String, String> properties;
+	private Map<String, Object> properties;
 	
 	private String correlationId;
 	
@@ -193,12 +193,12 @@ final public class Message implements Serializable, IMessage {
 	}
 	
 	@Override
-	public Map<String, String> getProperties() {
+	public Map<String, Object> getProperties() {
 		return this.properties;
 	}
 
 	@Override
-	public void setProperties(Map<String, String> properties) {
+	public void setProperties(Map<String, Object> properties) {
 		this.properties = properties;				
 	}
 


### PR DESCRIPTION
As reported in issue #147, property value should not be limited to String. This was a mistake. Fixing it now.
This will cause break existing applications if they were using lines like
String x = message.getProperties().get("propName");. Not sure if this alone warrants a major version change.