### PR TITLE
Adding support for multiple message body types.

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/IMessage.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/IMessage.java
@@ -75,7 +75,7 @@ public interface IMessage {
      * Gets the content type of this message.
      *
      * Optionally describes the payload of the message, with a descriptor following the format of 
-     * RFC2045, Section 5, for example "application/json".
+     * RFC2045, Section 5, for example "application/json". Note that content type is not same as message body type.
      * 
      * @return content type of this message
      */
@@ -183,21 +183,20 @@ public interface IMessage {
     public void setSessionId(String sessionId);
 
     /**
-     * Gets the body of this message as a byte array. It is up to client applications 
-     * to decode the bytes.
+     * Gets the body of this message. Client applications should extract message content based on body type.
      *
      * @return body of this message
      * @see <a href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads">Messages, payloads, and serialization</a>
      */
-    public byte[] getBody();
+    public MessageBody getBody();
 
     /**
-     * Sets the body of this message as a byte array.
+     * Sets the body of this message.
      *
      * @param body body of this message
      * @see #getBody()
      */
-    public void setBody(byte[] body);
+    public void setBody(MessageBody body);
 
     /**
      * Gets the map of user application properties of this message. Client 

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/Message.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/Message.java
@@ -4,7 +4,6 @@
 package com.microsoft.azure.servicebus;
 
 import java.io.Serializable;
-import java.nio.charset.Charset;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
@@ -19,11 +18,9 @@ import java.util.UUID;
 final public class Message implements Serializable, IMessage {
 	private static final long serialVersionUID = 7849508139219590863L;
 	
-	private static final Charset DEFAULT_CHAR_SET = Charset.forName("UTF-8");
-	
 	private static final String DEFAULT_CONTENT_TYPE = null;
 	
-	private static final byte[] DEFAULT_CONTENT = new byte[0];
+	private static final MessageBody DEFAULT_CONTENT = new MessageBody(new byte[0]);
 
 	private long deliveryCount;
 	
@@ -31,7 +28,7 @@ final public class Message implements Serializable, IMessage {
 	
 	private Duration timeToLive;
 	
-	private byte[] content;
+	private MessageBody body;
 	
 	private String contentType;
 	
@@ -72,33 +69,33 @@ final public class Message implements Serializable, IMessage {
 	
 	public Message(String content)
 	{
-		this(content.getBytes(DEFAULT_CHAR_SET));
+		this(new MessageBody(content));
 	}
 	
-	public Message(byte[] content)
+	public Message(MessageBody body)
 	{
-		this(content, DEFAULT_CONTENT_TYPE);
+		this(body, DEFAULT_CONTENT_TYPE);
 	}
 	
 	public Message(String content, String contentType)
 	{
-		this(content.getBytes(DEFAULT_CHAR_SET), contentType);
+		this(new MessageBody(content), contentType);
 	}
 	
-	public Message(byte[] content, String contentType)
+	public Message(MessageBody body, String contentType)
 	{
-		this(UUID.randomUUID().toString(), content, contentType);
+		this(UUID.randomUUID().toString(), body, contentType);
 	}
 	
 	public Message(String messageId, String content, String contentType)
 	{
-		this(messageId, content.getBytes(DEFAULT_CHAR_SET), contentType);
+		this(messageId, new MessageBody(content), contentType);
 	}
 
-	public Message(String messageId, byte[] content, String contentType)
+	public Message(String messageId, MessageBody body, String contentType)
 	{
 		this.messageId = messageId;
-		this.content = content;
+		this.body = body;
 		this.contentType = contentType;
 		this.properties = new HashMap<>();
 	}
@@ -185,13 +182,13 @@ final public class Message implements Serializable, IMessage {
 	}
 	
 	@Override
-	public byte[] getBody() {
-		return this.content;
+	public MessageBody getBody() {
+		return this.body;
 	}
 
 	@Override
-	public void setBody(byte[] content) {
-		this.content = content;
+	public void setBody(MessageBody body) {
+		this.body = body;
 	}
 	
 	@Override

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageBody.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageBody.java
@@ -1,0 +1,50 @@
+package com.microsoft.azure.servicebus;
+
+import java.util.List;
+
+public class MessageBody {
+    private MessageBodyType bodyType;
+    private Object value;
+    private List<Object> sequence;
+    private byte[] binaryData;
+    
+    public MessageBody(Object value)
+    {
+        this.bodyType = MessageBodyType.VALUE;
+        this.value = value;
+        this.sequence = null;
+        this.binaryData = null;
+    }
+    
+    public MessageBody(List<Object> sequence)
+    {
+        this.bodyType = MessageBodyType.SEQUENCE;
+        this.value = null;
+        this.sequence = sequence;
+        this.binaryData = null;
+    }
+    
+    public MessageBody(byte[] binaryData)
+    {
+        this.bodyType = MessageBodyType.BINARY;
+        this.value = null;
+        this.sequence = null;
+        this.binaryData = binaryData;
+    }
+    
+    public Object getValue() {
+        return value;
+    }
+    
+    public List<Object> getSequence() {
+        return sequence;
+    }
+    
+    public byte[] getBinaryData() {
+        return binaryData;
+    }
+    
+    public MessageBodyType getBodyType() {
+        return bodyType;
+    }
+}

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageBodyType.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageBodyType.java
@@ -1,0 +1,7 @@
+package com.microsoft.azure.servicebus;
+
+public enum MessageBodyType {
+    BINARY,
+    SEQUENCE,
+    VALUE
+}

--- a/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/SendReceiveTests.java
+++ b/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/SendReceiveTests.java
@@ -120,6 +120,13 @@ public abstract class SendReceiveTests extends Tests {
 	}
 	
 	@Test
+    public void testBasicReceiveAndDeleteWithBinaryData() throws InterruptedException, ServiceBusException, ExecutionException
+    {
+        this.receiver = ClientFactory.createMessageReceiverFromEntityPath(factory, this.receiveBuilder.getEntityPath(), ReceiveMode.RECEIVEANDDELETE);
+        TestCommons.testBasicReceiveAndDeleteWithBinaryData(this.sender, this.sessionId, this.receiver);
+    }
+	
+	@Test
 	public void testBasicReceiveBatchAndDelete() throws InterruptedException, ServiceBusException, ExecutionException
 	{
 		this.receiver = ClientFactory.createMessageReceiverFromEntityPath(factory, this.receiveBuilder.getEntityPath(), ReceiveMode.RECEIVEANDDELETE);

--- a/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/SessionTests.java
+++ b/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/SessionTests.java
@@ -130,6 +130,14 @@ public abstract class SessionTests extends Tests {
 	}
 	
 	@Test
+    public void testBasicReceiveAndDeleteWithBinaryData() throws InterruptedException, ServiceBusException, ExecutionException
+    {
+        String sessionId = TestUtils.getRandomString();
+        this.session = ClientFactory.acceptSessionFromEntityPath(this.factory, receiveBuilder.getEntityPath(), sessionId, ReceiveMode.RECEIVEANDDELETE);
+        TestCommons.testBasicReceiveAndDeleteWithBinaryData(this.sender, sessionId, this.session);
+    }
+	
+	@Test
 	public void testBasicReceiveBatchAndDelete() throws InterruptedException, ServiceBusException, ExecutionException
 	{
 		String sessionId = TestUtils.getRandomString();

--- a/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/TestCommons.java
+++ b/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/TestCommons.java
@@ -43,7 +43,8 @@ public class TestCommons {
 	public static void testBasicReceiveAndDelete(IMessageSender sender, String sessionId, IMessageReceiver receiver) throws InterruptedException, ServiceBusException, ExecutionException
 	{	
 		String messageId = UUID.randomUUID().toString();
-		Message message = new Message("AMQP message");
+		String messageBody = "AMQP message";
+		Message message = new Message(messageBody);
 		message.setMessageId(messageId);
 		if(sessionId != null)
 		{
@@ -54,9 +55,36 @@ public class TestCommons {
 		IMessage receivedMessage = receiver.receive();
 		Assert.assertNotNull("Message not received", receivedMessage);
 		Assert.assertEquals("Message Id did not match", messageId, receivedMessage.getMessageId());
+		Assert.assertEquals("Message Body Type did not match", MessageBodyType.VALUE, receivedMessage.getBody().getBodyType());
+		Assert.assertEquals("Message content did not match", messageBody, receivedMessage.getBody().getValue());
 		receivedMessage = receiver.receive(SHORT_WAIT_TIME);
 		Assert.assertNull("Message received again", receivedMessage);
 	}
+	
+	public static void testBasicReceiveAndDeleteWithBinaryData(IMessageSender sender, String sessionId, IMessageReceiver receiver) throws InterruptedException, ServiceBusException, ExecutionException
+    {   
+        String messageId = UUID.randomUUID().toString();
+        byte[] binaryData = new byte[200];
+        for(int i=0; i< binaryData.length; i++)
+        {
+            binaryData[i] = (byte)i;
+        }
+        Message message = new Message(new MessageBody(binaryData));
+        message.setMessageId(messageId);
+        if(sessionId != null)
+        {
+            message.setSessionId(sessionId);
+        }
+        sender.send(message);
+                
+        IMessage receivedMessage = receiver.receive();
+        Assert.assertNotNull("Message not received", receivedMessage);
+        Assert.assertEquals("Message Id did not match", messageId, receivedMessage.getMessageId());
+        Assert.assertEquals("Message Body Type did not match", MessageBodyType.BINARY, receivedMessage.getBody().getBodyType());
+        Assert.assertArrayEquals("Message content did not match", binaryData, receivedMessage.getBody().getBinaryData());
+        receivedMessage = receiver.receive(SHORT_WAIT_TIME);
+        Assert.assertNull("Message received again", receivedMessage);
+    }
 	
 	public static void testBasicReceiveBatchAndDelete(IMessageSender sender, String sessionId, IMessageReceiver receiver) throws InterruptedException, ServiceBusException, ExecutionException
 	{


### PR DESCRIPTION
With this change, I am adding support for message body types AMQPValue, AMQPSequence. So far we supported only messages of body type Data. Some customers are sending messages to Azure Service Bus using some other SDK  (java/.net/python) and receiving messages using our Java SDK. Not having support for other data types was a limitation raised by at least one customer.

This is a breaking change. There were few other breaking changes too, in recent fixes. I am planning to put all breaking changes in version 2.0. Need your feedback on the new API.

Note: Currently we can only send AMQPSequece messages to our service. When we receive them, they come as Data messages.