### PR TITLE
Fixing a memory leak in RequestResponseLink

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
@@ -381,15 +381,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 
 		final ReceiveLinkHandler handler = new ReceiveLinkHandler(this);
 		BaseHandler.setHandler(receiver, handler);
-		this.underlyingFactory.registerForConnectionError(receiver);
-
 		receiver.open();
-
-		if (this.receiveLink != null)
-		{			
-			this.underlyingFactory.deregisterForConnectionError(this.receiveLink);
-		}
-
 		this.receiveLink = receiver;
 	}
 	
@@ -587,7 +579,9 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 		}
 		
 		if (exception == null)
-		{			
+		{
+		    this.underlyingFactory.registerForConnectionError(this.receiveLink);
+		    
 			if (this.linkOpen != null && !this.linkOpen.getWork().isDone())
 			{
 				AsyncUtil.completeFuture(this.linkOpen.getWork(), this);
@@ -632,7 +626,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
                     this.closeAsync();
                 }
             }
-
+			
 			this.lastKnownLinkError = exception;
 		}
 	}
@@ -801,6 +795,8 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 			}
 			else
 			{
+			    this.underlyingFactory.deregisterForConnectionError(this.receiveLink);
+			    
 			    if (exception != null &&
 	                    (!(exception instanceof ServiceBusException) || !((ServiceBusException) exception).getIsTransient()))
 	            {

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageSender.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageSender.java
@@ -364,6 +364,7 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 	{
 		if (completionException == null)
 		{
+		    this.underlyingFactory.registerForConnectionError(this.sendLink);
 			this.lastKnownLinkError = null;
 			this.retryPolicy.resetRetryCount(this.getClientId());
 
@@ -450,6 +451,7 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 		}
 		else
 		{
+		    this.underlyingFactory.deregisterForConnectionError(this.sendLink);
 			this.lastKnownLinkError = completionException;
 			this.lastKnownErrorReportedAt = Instant.now();
 
@@ -593,16 +595,7 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 		
 		SendLinkHandler handler = new SendLinkHandler(CoreMessageSender.this);
 		BaseHandler.setHandler(sender, handler);
-
-		this.underlyingFactory.registerForConnectionError(sender);
-		sender.open();
-		
-		if (this.sendLink != null)
-		{
-			final Sender oldSender = this.sendLink;
-			this.underlyingFactory.deregisterForConnectionError(oldSender);
-		}
-		
+		sender.open();		
 		this.sendLink = sender;
 	}
 	

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
@@ -344,7 +344,7 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
 	    TRACE_LOGGER.info("Closing connection to host");
 	    // Important to copy the reference of the connection as a call to getConnection might create a new connection while we are still in this method
 	    Connection currentConnection = this.connection;
-	    if(connection != null)
+	    if(currentConnection != null)
 	    {
 	        Link[] links = this.registeredLinks.toArray(new Link[0]);
 	        
@@ -425,27 +425,28 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
 	                } catch (IOException e) {
 	                    AsyncUtil.completeFutureExceptionally(this.connetionCloseFuture, e);
 	                }
+	                
+	                Timer.schedule(new Runnable()
+	                {
+	                    @Override
+	                    public void run()
+	                    {
+	                        if (!MessagingFactory.this.connetionCloseFuture.isDone())
+	                        {
+	                            String errorMessage = "Closing MessagingFactory timed out.";
+	                            TRACE_LOGGER.warn(errorMessage);
+	                            MessagingFactory.this.connetionCloseFuture.completeExceptionally(new TimeoutException(errorMessage));
+	                        }
+	                    }
+	                },
+	                this.clientSettings.getOperationTimeout(), TimerType.OneTimeRun);
 	            }
-	            else if(this.connection == null || this.connection.getRemoteState() == EndpointState.CLOSED)
+	            else
 	            {
 	                this.connetionCloseFuture.complete(null);
+	                Timer.unregister(this.getClientId());
 	            }
 		    });
-		    
-		    Timer.schedule(new Runnable()
-            {
-                @Override
-                public void run()
-                {
-                    if (!MessagingFactory.this.connetionCloseFuture.isDone())
-                    {
-                        String errorMessage = "Closing MessagingFactory timed out.";
-                        TRACE_LOGGER.warn(errorMessage);
-                        MessagingFactory.this.connetionCloseFuture.completeExceptionally(new TimeoutException(errorMessage));
-                    }
-                }
-            },
-            this.clientSettings.getOperationTimeout(), TimerType.OneTimeRun);
 			
 			return this.connetionCloseFuture;
 		}
@@ -527,7 +528,10 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
 	@Override
 	public void registerForConnectionError(Link link)
 	{
-		this.registeredLinks.add(link);
+	    if(link != null)
+	    {
+	        this.registeredLinks.add(link);
+	    }
 	}
 
 	/**
@@ -536,7 +540,10 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
 	@Override
 	public void deregisterForConnectionError(Link link)
 	{
-		this.registeredLinks.remove(link);
+	    if(link != null)
+	    {
+	        this.registeredLinks.remove(link);
+	    }
 	}
 	
 	void scheduleOnReactorThread(final DispatchHandler handler) throws IOException

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
@@ -480,6 +480,7 @@ class RequestResponseLink extends ClientEntity{
 			if(completionException == null)
 			{
 			    TRACE_LOGGER.debug("Opened internal receive link of requestresponselink to {}", parent.linkPath);
+			    this.parent.underlyingFactory.registerForConnectionError(this.receiveLink);
 				this.openFuture.complete(null);
 				
 				// Send unlimited credit
@@ -511,6 +512,7 @@ class RequestResponseLink extends ClientEntity{
 			}
 			
 			TRACE_LOGGER.warn("Internal receive link of requestresponselink to '{}' encountered error.", this.parent.linkPath, exception);
+			this.parent.underlyingFactory.deregisterForConnectionError(this.receiveLink);
 			this.parent.amqpSender.closeInternals(false);
             this.parent.amqpSender.setClosed();
 			this.parent.completeAllPendingRequestsWithException(exception);
@@ -547,6 +549,7 @@ class RequestResponseLink extends ClientEntity{
 					else
 					{
 					    TRACE_LOGGER.warn("Internal receive link of requestresponselink to '{}' closed with error.", this.parent.linkPath, exception);
+					    this.parent.underlyingFactory.deregisterForConnectionError(this.receiveLink);
 					    this.parent.amqpSender.closeInternals(false);
 					    this.parent.amqpSender.setClosed();
 					    this.parent.completeAllPendingRequestsWithException(exception);
@@ -592,13 +595,6 @@ class RequestResponseLink extends ClientEntity{
 		}
 
 		public void setReceiveLink(Receiver receiveLink) {
-			if (this.receiveLink != null)
-			{
-				Receiver oldReceiver = this.receiveLink;
-				this.parent.underlyingFactory.deregisterForConnectionError(oldReceiver);
-			}
-			
-			this.parent.underlyingFactory.registerForConnectionError(receiveLink);
 			this.receiveLink = receiveLink;
 		}
 	}
@@ -685,6 +681,7 @@ class RequestResponseLink extends ClientEntity{
 			if(completionException == null)
 			{
 			    TRACE_LOGGER.debug("Opened internal send link of requestresponselink to {}", parent.linkPath);
+			    this.parent.underlyingFactory.registerForConnectionError(this.sendLink);
 				this.openFuture.complete(null);	
 				this.runSendLoop();
 			}
@@ -714,6 +711,7 @@ class RequestResponseLink extends ClientEntity{
 			}
 			
 			TRACE_LOGGER.warn("Internal send link of requestresponselink to '{}' encountered error.", this.parent.linkPath, exception);
+			this.parent.underlyingFactory.deregisterForConnectionError(this.sendLink);
 			this.parent.amqpReceiver.closeInternals(false);
             this.parent.amqpReceiver.setClosed();
 			this.parent.completeAllPendingRequestsWithException(exception);
@@ -750,6 +748,7 @@ class RequestResponseLink extends ClientEntity{
 					else
 					{
 					    TRACE_LOGGER.warn("Internal send link of requestresponselink to '{}' closed with error.", this.parent.linkPath, exception);
+					    this.parent.underlyingFactory.deregisterForConnectionError(this.sendLink);
 					    this.parent.amqpReceiver.closeInternals(false);
                         this.parent.amqpReceiver.setClosed();
 					    this.parent.completeAllPendingRequestsWithException(exception);
@@ -819,14 +818,7 @@ class RequestResponseLink extends ClientEntity{
 			// Doesn't happen as sends are settled on send
 		}		
 
-		public void setSendLink(Sender sendLink) {
-			if (this.sendLink != null)
-			{
-				Sender oldSender = this.sendLink;
-				this.parent.underlyingFactory.deregisterForConnectionError(oldSender);
-			}
-			
-			this.parent.underlyingFactory.registerForConnectionError(sendLink);
+		public void setSendLink(Sender sendLink) {			
 			this.sendLink = sendLink;
 			this.availableCredit = new AtomicInteger(0);
 		}


### PR DESCRIPTION
InternalSender of request-response link was registering a link with the factory, which means putting it in a linked list, and forgetting to remove it when the send link is closed by the service on idle timeout. That link object is leaking and holding a reference to another large object in the qpid library.