### PR TITLE
Controlling wait time for receiving messages in message/session pump

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageHandlerOptions.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageHandlerOptions.java
@@ -12,9 +12,11 @@ public final class MessageHandlerOptions {
     private static final boolean DEFAULT_AUTO_COMPLETE = true;
     private static final int DEFAULT_MAX_CONCURRENT_CALLS = 1;
     private static final int DEFAULT_MAX_RENEW_TIME_MINUTES = 5;
+    private static final int DEFAULT_MESSAGE_WAIT_TIME_MINUTES = 1;
 
     private boolean autoComplete;
     private Duration maxAutoRenewDuration;
+    private Duration messageWaitDuration;
     private int maxConcurrentCalls;
 
     /**
@@ -35,9 +37,22 @@ public final class MessageHandlerOptions {
      * @param maxAutoRenewDuration - Maximum duration within which the client keeps renewing the message lock if the processing of the message is not completed by the handler.
      */
     public MessageHandlerOptions(int maxConcurrentCalls, boolean autoComplete, Duration maxAutoRenewDuration) {
+        this(maxConcurrentCalls, autoComplete, maxAutoRenewDuration, Duration.ofMinutes(DEFAULT_MESSAGE_WAIT_TIME_MINUTES));
+    }
+
+    /**
+     * Create a instance of {@link MessageHandlerOptions}.
+     *
+     * @param maxConcurrentCalls   maximum number of concurrent calls to the onMessage handler
+     * @param autoComplete         true if the pump should automatically complete message after onMessageHandler action is completed. false otherwise.
+     * @param maxAutoRenewDuration - Maximum duration within which the client keeps renewing the message lock if the processing of the message is not completed by the handler.
+     * @param messageWaitDuration  duration to wait for receiving the message
+     */
+    public MessageHandlerOptions(int maxConcurrentCalls, boolean autoComplete, Duration maxAutoRenewDuration, Duration messageWaitDuration) {
         this.autoComplete = autoComplete;
         this.maxAutoRenewDuration = maxAutoRenewDuration;
         this.maxConcurrentCalls = maxConcurrentCalls;
+        this.messageWaitDuration = messageWaitDuration;
     }
 
     /**
@@ -66,6 +81,12 @@ public final class MessageHandlerOptions {
     public Duration getMaxAutoRenewDuration() {
         return this.maxAutoRenewDuration;
     }
+
+    /**
+     * Gets the time to wait for receiving a message. Defaults to 1 minute.
+     * @return The wait duration for receive calls.
+     */
+    public Duration getMessageWaitDuration() { return this.messageWaitDuration; }
 
     @Override
     public String toString() {

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/SessionHandlerOptions.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/SessionHandlerOptions.java
@@ -14,9 +14,11 @@ public final class SessionHandlerOptions {
     private static final int DEFAULT_MAX_CONCURRENT_SESSIONS = 1;
     private static final int DEFAULT_MAX_CONCURRENT_CALLS_PER_SESSION = 1;
     private static final int DEFAULT_MAX_RENEW_TIME_MINUTES = 5;
+    private static final int DEFAULT_MESSAGE_WAIT_TIME_MINUTES = 1;
 
     private boolean autoComplete;
     private Duration maxAutoRenewDuration;
+    private Duration messageWaitDuration;
     private int maxConcurrentSessions;
     private int maxConcurrentCallsPerSession;
 
@@ -26,6 +28,7 @@ public final class SessionHandlerOptions {
      * Default {@link SessionHandlerOptions#getMaxConcurrentCallsPerSession()} is 1
      * Default {@link SessionHandlerOptions#getMaxAutoRenewDuration()} is 5 minutes
      * Default {@link SessionHandlerOptions#isAutoComplete()} is true.
+     * Default {@link SessionHandlerOptions#getMessageWaitDuration()} is 1 minute
      */
     public SessionHandlerOptions() {
         this(DEFAULT_MAX_CONCURRENT_SESSIONS, DEFAULT_AUTO_COMPLETE, Duration.ofMinutes(DEFAULT_MAX_RENEW_TIME_MINUTES));
@@ -49,10 +52,23 @@ public final class SessionHandlerOptions {
      *                                     is not completed by the handler.
      */
     public SessionHandlerOptions(int maxConcurrentSessions, int maxConcurrentCallsPerSession, boolean autoComplete, Duration maxAutoRenewDuration) {
+        this(maxConcurrentSessions, maxConcurrentCallsPerSession, autoComplete, maxAutoRenewDuration, Duration.ofMinutes(DEFAULT_MESSAGE_WAIT_TIME_MINUTES));
+    }
+
+    /**
+     * @param maxConcurrentSessions        maximum number of concurrent sessions accepted by the session pump
+     * @param maxConcurrentCallsPerSession maximum number of concurrent calls to the onMessage handler
+     * @param autoComplete                 true if the pump should automatically complete message after onMessageHandler action is completed. false otherwise
+     * @param maxAutoRenewDuration         Maximum duration within which the client keeps renewing the session lock if the processing of the session messages or onclose action
+     *                                     is not completed by the handler.
+     * @param messageWaitDuration          Duration to wait for receiving the message
+     */
+    public SessionHandlerOptions(int maxConcurrentSessions, int maxConcurrentCallsPerSession, boolean autoComplete, Duration maxAutoRenewDuration, Duration messageWaitDuration) {
         this.maxConcurrentSessions = maxConcurrentSessions;
         this.maxConcurrentCallsPerSession = maxConcurrentCallsPerSession;
         this.autoComplete = autoComplete;
         this.maxAutoRenewDuration = maxAutoRenewDuration;
+        this.messageWaitDuration = messageWaitDuration;
     }
 
     /**
@@ -91,6 +107,12 @@ public final class SessionHandlerOptions {
     public Duration getMaxAutoRenewDuration() {
         return this.maxAutoRenewDuration;
     }
+
+    /**
+     * Gets the time to wait for receiving a message. Defaults to 1 minute.
+     * @return The wait duration for receive calls.
+     */
+    public Duration getMessageWaitDuration() { return this.messageWaitDuration; }
 
     @Override
     public String toString() {


### PR DESCRIPTION
Exposing a new option for MessageHandler and SessionHandler which controls the wait time for receiving the message.

Fixes #197 