### PR TITLE
Chaning SLF4J dependency version to 1.7.

### DIFF
--- a/azure-servicebus/azure-servicebus.pom
+++ b/azure-servicebus/azure-servicebus.pom
@@ -67,7 +67,7 @@
 		<dependency>
 	 	    <groupId>org.slf4j</groupId> 
 	 	    <artifactId>slf4j-api</artifactId> 
-	 	    <version>1.8.0-alpha2</version>
+	 	    <version>1.7.0</version>
 	  	</dependency>
 		<dependency>
 			 <groupId>com.microsoft.azure</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<properties>
 		<proton-j-version>0.22.0</proton-j-version>
 	  	<junit-version>4.12</junit-version>
-		<slf4j-version>1.8.0-alpha2</slf4j-version>
+		<slf4j-version>1.7.0</slf4j-version>
 		<client-current-version>2.0.0-preview2</client-current-version>
 	</properties>
 	


### PR DESCRIPTION
Looks like 1.8 is breaking some customers' scenario. It was anyway oversight on our part to take a dependency on alpha version.