### PR TITLE
Adding a property needed for additional validation to check client type

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/BrowsableMessageSession.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/BrowsableMessageSession.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import com.microsoft.azure.servicebus.primitives.MessagingEntityType;
 import com.microsoft.azure.servicebus.primitives.MessagingFactory;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 
@@ -19,8 +20,8 @@ import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 final class BrowsableMessageSession extends MessageSession {
     private static final String INVALID_OPERATION_ERROR_MESSAGE = "Unsupported operation on a browse only session.";
 
-    BrowsableMessageSession(String sessionId, MessagingFactory messagingFactory, String entityPath) {
-        super(messagingFactory, entityPath, sessionId, ReceiveMode.PEEKLOCK);
+    BrowsableMessageSession(String sessionId, MessagingFactory messagingFactory, String entityPath, MessagingEntityType entityType) {
+        super(messagingFactory, entityPath, entityType, sessionId, ReceiveMode.PEEKLOCK);
 //		try {
 //			this.initializeAsync().get();
 //		} catch (InterruptedException | ExecutionException e) {

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/ClientFactory.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/ClientFactory.java
@@ -7,6 +7,7 @@ import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 
 import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
+import com.microsoft.azure.servicebus.primitives.MessagingEntityType;
 import com.microsoft.azure.servicebus.primitives.MessagingFactory;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import com.microsoft.azure.servicebus.primitives.Util;
@@ -48,6 +49,10 @@ public final class ClientFactory {
         return Utils.completeFuture(createMessageSenderFromConnectionStringBuilderAsync(amqpConnectionStringBuilder));
     }
     
+    static IMessageSender createMessageSenderFromConnectionStringBuilder(ConnectionStringBuilder amqpConnectionStringBuilder, MessagingEntityType entityType) throws InterruptedException, ServiceBusException {
+        return Utils.completeFuture(createMessageSenderFromConnectionStringBuilderAsync(amqpConnectionStringBuilder, entityType));
+    }
+    
     /**
      * Creates a message sender to the entity using the client settings.
      * @param namespaceName namespace of entity
@@ -73,6 +78,10 @@ public final class ClientFactory {
     public static IMessageSender createMessageSenderFromEntityPath(URI namespaceEndpointURI, String entityPath, ClientSettings clientSettings) throws InterruptedException, ServiceBusException {
         return Utils.completeFuture(createMessageSenderFromEntityPathAsync(namespaceEndpointURI, entityPath, clientSettings));
     }
+    
+    static IMessageSender createMessageSenderFromEntityPath(URI namespaceEndpointURI, String entityPath, MessagingEntityType entityType, ClientSettings clientSettings) throws InterruptedException, ServiceBusException {
+        return Utils.completeFuture(createMessageSenderFromEntityPathAsync(namespaceEndpointURI, entityPath, entityType, clientSettings));
+    }
 
     /**
      * Creates a message sender to the entity.
@@ -84,6 +93,10 @@ public final class ClientFactory {
      */
     public static IMessageSender createMessageSenderFromEntityPath(MessagingFactory messagingFactory, String entityPath) throws InterruptedException, ServiceBusException {
         return Utils.completeFuture(createMessageSenderFromEntityPathAsync(messagingFactory, entityPath));
+    }
+    
+    static IMessageSender createMessageSenderFromEntityPath(MessagingFactory messagingFactory, String entityPath, MessagingEntityType entityType) throws InterruptedException, ServiceBusException {
+        return Utils.completeFuture(createMessageSenderFromEntityPathAsync(messagingFactory, entityPath, entityType));
     }
 
     /**
@@ -127,6 +140,11 @@ public final class ClientFactory {
         return createMessageSenderFromEntityPathAsync(amqpConnectionStringBuilder.getEndpoint(), amqpConnectionStringBuilder.getEntityPath(),  Util.getClientSettingsFromConnectionStringBuilder(amqpConnectionStringBuilder));
     }
     
+    static CompletableFuture<IMessageSender> createMessageSenderFromConnectionStringBuilderAsync(ConnectionStringBuilder amqpConnectionStringBuilder, MessagingEntityType entityType) {
+        Utils.assertNonNull("amqpConnectionStringBuilder", amqpConnectionStringBuilder);
+        return createMessageSenderFromEntityPathAsync(amqpConnectionStringBuilder.getEndpoint(), amqpConnectionStringBuilder.getEntityPath(), entityType, Util.getClientSettingsFromConnectionStringBuilder(amqpConnectionStringBuilder));
+    }
+    
     /**
      * Creates a message sender asynchronously to the entity using the client settings.
      * @param namespaceName namespace name of entity
@@ -150,8 +168,13 @@ public final class ClientFactory {
      */
     public static CompletableFuture<IMessageSender> createMessageSenderFromEntityPathAsync(URI namespaceEndpointURI, String entityPath, ClientSettings clientSettings)
     {
+        return createMessageSenderFromEntityPathAsync(namespaceEndpointURI, entityPath, null, clientSettings);
+    }
+    
+    static CompletableFuture<IMessageSender> createMessageSenderFromEntityPathAsync(URI namespaceEndpointURI, String entityPath, MessagingEntityType entityType, ClientSettings clientSettings)
+    {
         Utils.assertNonNull("namespaceEndpointURI", namespaceEndpointURI);
-        MessageSender sender = new MessageSender(namespaceEndpointURI, entityPath, null, clientSettings);
+        MessageSender sender = new MessageSender(namespaceEndpointURI, entityPath, null, entityType, clientSettings);
         return sender.initializeAsync().thenApply((v) -> sender);
     }
 
@@ -162,8 +185,12 @@ public final class ClientFactory {
      * @return a CompletableFuture representing the pending creating of IMessageSender instance
      */
     public static CompletableFuture<IMessageSender> createMessageSenderFromEntityPathAsync(MessagingFactory messagingFactory, String entityPath) {
+        return createMessageSenderFromEntityPathAsync(messagingFactory, entityPath, null);
+    }
+    
+    static CompletableFuture<IMessageSender> createMessageSenderFromEntityPathAsync(MessagingFactory messagingFactory, String entityPath, MessagingEntityType entityType) {
         Utils.assertNonNull("messagingFactory", messagingFactory);
-        MessageSender sender = new MessageSender(messagingFactory, entityPath);
+        MessageSender sender = new MessageSender(messagingFactory, entityPath, entityType);
         return sender.initializeAsync().thenApply((v) -> sender);
     }
 
@@ -182,7 +209,7 @@ public final class ClientFactory {
     public static CompletableFuture<IMessageSender> createTransferMessageSenderFromEntityPathAsync(MessagingFactory messagingFactory, String entityPath, String viaEntityPath)
     {
         Utils.assertNonNull("messagingFactory", messagingFactory);
-        MessageSender sender = new MessageSender(messagingFactory, viaEntityPath, entityPath);
+        MessageSender sender = new MessageSender(messagingFactory, viaEntityPath, entityPath, null);
         return sender.initializeAsync().thenApply((v) -> sender);
     }
 
@@ -320,6 +347,10 @@ public final class ClientFactory {
     public static IMessageReceiver createMessageReceiverFromEntityPath(MessagingFactory messagingFactory, String entityPath, ReceiveMode receiveMode) throws InterruptedException, ServiceBusException {
         return Utils.completeFuture(createMessageReceiverFromEntityPathAsync(messagingFactory, entityPath, receiveMode));
     }
+    
+    static IMessageReceiver createMessageReceiverFromEntityPath(MessagingFactory messagingFactory, String entityPath, MessagingEntityType entityType, ReceiveMode receiveMode) throws InterruptedException, ServiceBusException {
+        return Utils.completeFuture(createMessageReceiverFromEntityPathAsync(messagingFactory, entityPath, entityType, receiveMode));
+    }
 
     /**
      * Create {@link IMessageReceiver} in default {@link ReceiveMode#PEEKLOCK} mode asynchronously from connection string with <a href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-sas">Shared Access Signatures</a>
@@ -411,7 +442,7 @@ public final class ClientFactory {
     public static CompletableFuture<IMessageReceiver> createMessageReceiverFromEntityPathAsync(URI namespaceEndpointURI, String entityPath, ClientSettings clientSettings, ReceiveMode receiveMode) {
         Utils.assertNonNull("namespaceEndpointURI", namespaceEndpointURI);
         Utils.assertNonNull("entityPath", entityPath);
-        MessageReceiver receiver = new MessageReceiver(namespaceEndpointURI, entityPath, clientSettings, receiveMode);
+        MessageReceiver receiver = new MessageReceiver(namespaceEndpointURI, entityPath, null, clientSettings, receiveMode);
         return receiver.initializeAsync().thenApply((v) -> receiver);
     }
 
@@ -433,8 +464,12 @@ public final class ClientFactory {
      * @return a CompletableFuture representing the pending creation of message receiver
      */
     public static CompletableFuture<IMessageReceiver> createMessageReceiverFromEntityPathAsync(MessagingFactory messagingFactory, String entityPath, ReceiveMode receiveMode) {
+        return createMessageReceiverFromEntityPathAsync(messagingFactory, entityPath, null, receiveMode);
+    }
+    
+    static CompletableFuture<IMessageReceiver> createMessageReceiverFromEntityPathAsync(MessagingFactory messagingFactory, String entityPath, MessagingEntityType entityType, ReceiveMode receiveMode) {
         Utils.assertNonNull("messagingFactory", messagingFactory);
-        MessageReceiver receiver = new MessageReceiver(messagingFactory, entityPath, receiveMode);
+        MessageReceiver receiver = new MessageReceiver(messagingFactory, entityPath, entityType, receiveMode);
         return receiver.initializeAsync().thenApply((v) -> receiver);
     }
 
@@ -675,7 +710,7 @@ public final class ClientFactory {
     public static CompletableFuture<IMessageSession> acceptSessionFromEntityPathAsync(URI namespaceEndpointURI, String entityPath, String sessionId, ClientSettings clientSettings, ReceiveMode receiveMode) {
         Utils.assertNonNull("namespaceEndpointURI", namespaceEndpointURI);
         Utils.assertNonNull("entityPath", entityPath);
-        MessageSession session = new MessageSession(namespaceEndpointURI, entityPath, sessionId, clientSettings, receiveMode);
+        MessageSession session = new MessageSession(namespaceEndpointURI, entityPath, null, sessionId, clientSettings, receiveMode);
         return session.initializeAsync().thenApply((v) -> session);
     }
 
@@ -699,8 +734,12 @@ public final class ClientFactory {
      * @return a CompletableFuture representing the pending session accepting
      */
     public static CompletableFuture<IMessageSession> acceptSessionFromEntityPathAsync(MessagingFactory messagingFactory, String entityPath, String sessionId, ReceiveMode receiveMode) {
+        return acceptSessionFromEntityPathAsync(messagingFactory, entityPath, null, sessionId, receiveMode);
+    }
+    
+    static CompletableFuture<IMessageSession> acceptSessionFromEntityPathAsync(MessagingFactory messagingFactory, String entityPath, MessagingEntityType entityType, String sessionId, ReceiveMode receiveMode) {
         Utils.assertNonNull("messagingFactory", messagingFactory);
-        MessageSession session = new MessageSession(messagingFactory, entityPath, sessionId, receiveMode);
+        MessageSession session = new MessageSession(messagingFactory, entityPath, entityType, sessionId, receiveMode);
         return session.initializeAsync().thenApply((v) -> session);
     }
 }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageSession.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageSession.java
@@ -7,19 +7,20 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 
+import com.microsoft.azure.servicebus.primitives.MessagingEntityType;
 import com.microsoft.azure.servicebus.primitives.MessagingFactory;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 
 public class MessageSession extends MessageReceiver implements IMessageSession {
     private String requestedSessionId;
     
-    MessageSession(URI namespaceEndpointURI, String entityPath, String requestedSessionId, ClientSettings clientSettings, ReceiveMode receiveMode) {
-        super(namespaceEndpointURI, entityPath, clientSettings, receiveMode);
+    MessageSession(URI namespaceEndpointURI, String entityPath, MessagingEntityType entityType, String requestedSessionId, ClientSettings clientSettings, ReceiveMode receiveMode) {
+        super(namespaceEndpointURI, entityPath, entityType, clientSettings, receiveMode);
         this.requestedSessionId = requestedSessionId;
     }
 
-    MessageSession(MessagingFactory messagingFactory, String entityPath, String requestedSessionId, ReceiveMode receiveMode) {
-        super(messagingFactory, entityPath, receiveMode);
+    MessageSession(MessagingFactory messagingFactory, String entityPath, MessagingEntityType entityType, String requestedSessionId, ReceiveMode receiveMode) {
+        super(messagingFactory, entityPath, entityType, receiveMode);
         this.requestedSessionId = requestedSessionId;
     }
 

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/QueueClient.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/QueueClient.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
 import com.microsoft.azure.servicebus.primitives.ExceptionUtil;
+import com.microsoft.azure.servicebus.primitives.MessagingEntityType;
 import com.microsoft.azure.servicebus.primitives.MessagingFactory;
 import com.microsoft.azure.servicebus.primitives.MiscRequestResponseOperationHandler;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
@@ -77,12 +78,12 @@ public final class QueueClient extends InitializableEntity implements IQueueClie
     private CompletableFuture<Void> createInternals(MessagingFactory factory, String queuePath, ReceiveMode receiveMode) {
         this.factory = factory;
 
-        CompletableFuture<Void> postSessionBrowserFuture = MiscRequestResponseOperationHandler.create(factory, queuePath).thenAcceptAsync((msoh) -> {
+        CompletableFuture<Void> postSessionBrowserFuture = MiscRequestResponseOperationHandler.create(factory, queuePath, MessagingEntityType.QUEUE).thenAcceptAsync((msoh) -> {
             this.miscRequestResponseHandler = msoh;
-            this.sessionBrowser = new SessionBrowser(factory, queuePath, msoh);
+            this.sessionBrowser = new SessionBrowser(factory, queuePath, MessagingEntityType.QUEUE, msoh);
         });
 
-        this.messageAndSessionPump = new MessageAndSessionPump(factory, queuePath, receiveMode);
+        this.messageAndSessionPump = new MessageAndSessionPump(factory, queuePath, MessagingEntityType.QUEUE, receiveMode);
         CompletableFuture<Void> messagePumpInitFuture = this.messageAndSessionPump.initializeAsync();
 
         return CompletableFuture.allOf(postSessionBrowserFuture, messagePumpInitFuture);
@@ -94,7 +95,7 @@ public final class QueueClient extends InitializableEntity implements IQueueClie
             if(this.senderCreationFuture == null)
             {
                 this.senderCreationFuture = new CompletableFuture<Void>();
-                ClientFactory.createMessageSenderFromEntityPathAsync(this.factory, this.queuePath).handleAsync((sender, ex) ->
+                ClientFactory.createMessageSenderFromEntityPathAsync(this.factory, this.queuePath, MessagingEntityType.QUEUE).handleAsync((sender, ex) ->
                 {
                     if(ex == null)
                     {

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/SessionBrowser.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/SessionBrowser.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.microsoft.azure.servicebus.primitives.MessagingEntityType;
 import com.microsoft.azure.servicebus.primitives.MessagingFactory;
 import com.microsoft.azure.servicebus.primitives.MiscRequestResponseOperationHandler;
 
@@ -22,11 +23,13 @@ final class SessionBrowser {
 
     private final MessagingFactory messagingFactory;
     private final String entityPath;
+    private final MessagingEntityType entityType;
     private MiscRequestResponseOperationHandler miscRequestResponseHandler;
 
-    SessionBrowser(MessagingFactory messagingFactory, String entityPath, MiscRequestResponseOperationHandler miscRequestResponseHandler) {
+    SessionBrowser(MessagingFactory messagingFactory, String entityPath, MessagingEntityType entityType, MiscRequestResponseOperationHandler miscRequestResponseHandler) {
         this.messagingFactory = messagingFactory;
         this.entityPath = entityPath;
+        this.entityType = entityType;
         this.miscRequestResponseHandler = miscRequestResponseHandler;
     }
 
@@ -51,7 +54,7 @@ final class SessionBrowser {
                 int initFutureIndex = 0;
                 String newLastSessionId = sessionIds[sessionIds.length - 1];
                 for (String sessionId : sessionIds) {
-                    BrowsableMessageSession browsableSession = new BrowsableMessageSession(sessionId, this.messagingFactory, this.entityPath);
+                    BrowsableMessageSession browsableSession = new BrowsableMessageSession(sessionId, this.messagingFactory, this.entityPath, this.entityType);
                     sessionsList.add(browsableSession);
                     initFutures[initFutureIndex++] = browsableSession.initializeAsync();
                 }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/SubscriptionClient.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/SubscriptionClient.java
@@ -15,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
+import com.microsoft.azure.servicebus.primitives.MessagingEntityType;
 import com.microsoft.azure.servicebus.primitives.MessagingFactory;
 import com.microsoft.azure.servicebus.primitives.MiscRequestResponseOperationHandler;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
@@ -79,12 +80,12 @@ public final class SubscriptionClient extends InitializableEntity implements ISu
 	private CompletableFuture<Void> createPumpAndBrowserAsync(MessagingFactory factory)
 	{
 	    this.factory = factory;
-		CompletableFuture<Void> postSessionBrowserFuture = MiscRequestResponseOperationHandler.create(factory, this.subscriptionPath).thenAcceptAsync((msoh) -> {
+		CompletableFuture<Void> postSessionBrowserFuture = MiscRequestResponseOperationHandler.create(factory, this.subscriptionPath, MessagingEntityType.SUBSCRIPTION).thenAcceptAsync((msoh) -> {
 			this.miscRequestResponseHandler = msoh;
-			this.sessionBrowser = new SessionBrowser(factory, this.subscriptionPath, msoh);
+			this.sessionBrowser = new SessionBrowser(factory, this.subscriptionPath, MessagingEntityType.SUBSCRIPTION, msoh);
 		});		
 		
-		this.messageAndSessionPump = new MessageAndSessionPump(factory, this.subscriptionPath, receiveMode);
+		this.messageAndSessionPump = new MessageAndSessionPump(factory, this.subscriptionPath, MessagingEntityType.SUBSCRIPTION, receiveMode);
 		CompletableFuture<Void> messagePumpInitFuture = this.messageAndSessionPump.initializeAsync();
 		
 		return CompletableFuture.allOf(postSessionBrowserFuture, messagePumpInitFuture);

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/TopicClient.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/TopicClient.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
+import com.microsoft.azure.servicebus.primitives.MessagingEntityType;
 import com.microsoft.azure.servicebus.primitives.MessagingFactory;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import com.microsoft.azure.servicebus.primitives.StringUtil;
@@ -31,7 +32,7 @@ public final class TopicClient extends InitializableEntity implements ITopicClie
 
     public TopicClient(ConnectionStringBuilder amqpConnectionStringBuilder) throws InterruptedException, ServiceBusException {
         this();
-        this.sender = ClientFactory.createMessageSenderFromConnectionStringBuilder(amqpConnectionStringBuilder);
+        this.sender = ClientFactory.createMessageSenderFromConnectionStringBuilder(amqpConnectionStringBuilder, MessagingEntityType.TOPIC);
         this.browser = new MessageBrowser((MessageSender) sender);
         if (TRACE_LOGGER.isInfoEnabled()) {
             TRACE_LOGGER.info("Created topic client to connection string '{}'", amqpConnectionStringBuilder.toLoggableString());
@@ -46,7 +47,7 @@ public final class TopicClient extends InitializableEntity implements ITopicClie
     public TopicClient(URI namespaceEndpointURI, String topicPath, ClientSettings clientSettings) throws InterruptedException, ServiceBusException
     {
         this();
-        this.sender = ClientFactory.createMessageSenderFromEntityPath(namespaceEndpointURI, topicPath, clientSettings);
+        this.sender = ClientFactory.createMessageSenderFromEntityPath(namespaceEndpointURI, topicPath, MessagingEntityType.TOPIC, clientSettings);
         this.browser = new MessageBrowser((MessageSender) sender);
         if (TRACE_LOGGER.isInfoEnabled()) {
             TRACE_LOGGER.info("Created topic client to topic '{}/{}'", namespaceEndpointURI.toString(), topicPath);
@@ -55,7 +56,7 @@ public final class TopicClient extends InitializableEntity implements ITopicClie
 
     TopicClient(MessagingFactory factory, String topicPath) throws InterruptedException, ServiceBusException {
         this();
-        this.sender = ClientFactory.createMessageSenderFromEntityPath(factory, topicPath);
+        this.sender = ClientFactory.createMessageSenderFromEntityPath(factory, topicPath, MessagingEntityType.TOPIC);
         this.browser = new MessageBrowser((MessageSender) sender);
         TRACE_LOGGER.info("Created topic client to topic '{}'", topicPath);
     }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/Utils.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/Utils.java
@@ -18,9 +18,20 @@ public final class Utils {
             throw ie;
         } catch (ExecutionException ee) {
             Throwable cause = ee.getCause();
-            if (cause instanceof ServiceBusException) {
+            if(cause instanceof RuntimeException)
+            {
+            	throw (RuntimeException)cause;
+            }
+            else if (cause instanceof Error)
+            {
+            	throw (Error)cause;
+            }
+            else if (cause instanceof ServiceBusException)
+            {
                 throw (ServiceBusException) cause;
-            } else {
+            }
+            else
+            {
                 throw new ServiceBusException(true, cause);
             }
         }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientConstants.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientConstants.java
@@ -65,6 +65,7 @@ public final class ClientConstants
     public static final Symbol ENTITY_ALREADY_EXISTS_ERROR = Symbol.getSymbol(AmqpConstants.VENDOR + ":entity-already-exists");
     public static final Symbol SESSION_FILTER = Symbol.getSymbol(AmqpConstants.VENDOR + ":session-filter");
     public static final Symbol LOCKED_UNTIL_UTC = Symbol.getSymbol(AmqpConstants.VENDOR + ":locked-until-utc");
+	public final static Symbol ENTITY_TYPE_PROPERTY = Symbol.getSymbol(AmqpConstants.VENDOR + ":entity-type");
 	
 	public static final String DEADLETTER_REASON_HEADER = "DeadLetterReason";
     public static final String DEADLETTER_ERROR_DESCRIPTION_HEADER = "DeadLetterErrorDescription";

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/Controller.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/Controller.java
@@ -43,6 +43,7 @@ class Controller {
             CompletableFuture<CoreMessageSender> senderFuture = CoreMessageSender.create(
                     this.messagingFactory,
                     StringUtil.getShortRandomString(),
+                    null,
                     Controller.getControllerLinkSettings(this.messagingFactory));
             CompletableFuture<Void> postSenderCreationFuture = new CompletableFuture<Void>();
             senderFuture.handleAsync((s, coreSenderCreationEx) -> {

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingEntityType.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingEntityType.java
@@ -1,0 +1,21 @@
+package com.microsoft.azure.servicebus.primitives;
+
+// For internal use only. 
+// Integers are to achieve parity with .net enums which are integer by default
+public enum MessagingEntityType {
+	QUEUE(0),
+	TOPIC(1),
+	SUBSCRIPTION(2),
+	FILTER(3);
+	
+	private int enumValue;
+	MessagingEntityType(int enumValue)
+	{
+		this.enumValue = enumValue;
+	}
+	
+	public int getIntValue()
+	{
+		return this.enumValue;
+	}
+}

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
@@ -693,16 +693,16 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
         return Timer.schedule(validityRenewer, Duration.ofSeconds(renewInterval), TimerType.OneTimeRun);
 	}
 	
-	CompletableFuture<RequestResponseLink> obtainRequestResponseLinkAsync(String entityPath)
+	CompletableFuture<RequestResponseLink> obtainRequestResponseLinkAsync(String entityPath, MessagingEntityType entityType)
 	{
 	    this.throwIfClosed(null);
-	    return this.managementLinksCache.obtainRequestResponseLinkAsync(entityPath, null);
+	    return this.managementLinksCache.obtainRequestResponseLinkAsync(entityPath, null, entityType);
 	}
 
-    CompletableFuture<RequestResponseLink> obtainRequestResponseLinkAsync(String entityPath, String transferDestinationPath)
+    CompletableFuture<RequestResponseLink> obtainRequestResponseLinkAsync(String entityPath, String transferDestinationPath, MessagingEntityType entityType)
     {
         this.throwIfClosed(null);
-        return this.managementLinksCache.obtainRequestResponseLinkAsync(entityPath, transferDestinationPath);
+        return this.managementLinksCache.obtainRequestResponseLinkAsync(entityPath, transferDestinationPath, entityType);
     }
 	
 	void releaseRequestResponseLink(String entityPath)
@@ -734,7 +734,7 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
 	        String requestResponseLinkPath = RequestResponseLink.getCBSNodeLinkPath();
 	        TRACE_LOGGER.info("Creating CBS link to {}", requestResponseLinkPath);
 	        CompletableFuture<Void> crateAndAssignRequestResponseLink =
-	                        RequestResponseLink.createAsync(this, this.getClientId() + "-cbs", requestResponseLinkPath, null, null, null)
+	                        RequestResponseLink.createAsync(this, this.getClientId() + "-cbs", requestResponseLinkPath, null, null, null, null)
                                     .handleAsync((cbsLink, ex) ->
 	                        {
 	                            if(ex == null)

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MiscRequestResponseOperationHandler.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MiscRequestResponseOperationHandler.java
@@ -17,21 +17,29 @@ public final class MiscRequestResponseOperationHandler extends ClientEntity
     
 	private final Object requestResonseLinkCreationLock = new Object();
 	private final String entityPath;
+	private final MessagingEntityType entityType;
 	private final MessagingFactory underlyingFactory;
 	private RequestResponseLink requestResponseLink;
 	private CompletableFuture<Void> requestResponseLinkCreationFuture;
 	
-	private MiscRequestResponseOperationHandler(MessagingFactory factory, String linkName, String entityPath)
+	private MiscRequestResponseOperationHandler(MessagingFactory factory, String linkName, String entityPath, MessagingEntityType entityType)
 	{
 		super(linkName);
 		
 		this.underlyingFactory = factory;
 		this.entityPath = entityPath;
+		this.entityType = entityType;
 	}	
 	
+	@Deprecated
 	public static CompletableFuture<MiscRequestResponseOperationHandler> create(MessagingFactory factory, String entityPath)
 	{
-	    MiscRequestResponseOperationHandler requestResponseOperationHandler = new MiscRequestResponseOperationHandler(factory, StringUtil.getShortRandomString(), entityPath);
+	   return create(factory, entityPath, null);
+	}
+	
+	public static CompletableFuture<MiscRequestResponseOperationHandler> create(MessagingFactory factory, String entityPath, MessagingEntityType entityType)
+	{
+	    MiscRequestResponseOperationHandler requestResponseOperationHandler = new MiscRequestResponseOperationHandler(factory, StringUtil.getShortRandomString(), entityPath, entityType);
 	    return CompletableFuture.completedFuture(requestResponseOperationHandler);		
 	}
 	
@@ -53,7 +61,7 @@ public final class MiscRequestResponseOperationHandler extends ClientEntity
             if(this.requestResponseLinkCreationFuture == null)
             {                
                 this.requestResponseLinkCreationFuture = new CompletableFuture<Void>();
-                this.underlyingFactory.obtainRequestResponseLinkAsync(this.entityPath).handleAsync((rrlink, ex) ->
+                this.underlyingFactory.obtainRequestResponseLinkAsync(this.entityPath, this.entityType).handleAsync((rrlink, ex) ->
                 {
                     if(ex == null)
                     {

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
@@ -59,6 +59,7 @@ class RequestResponseLink extends ClientEntity{
 	private InternalSender amqpSender;
 	private boolean isRecreateLinksInProgress;
 	private Map<Symbol, Object> additionalProperties;
+	private MessagingEntityType entityType;
 	
 	public static CompletableFuture<RequestResponseLink> createAsync(
 			MessagingFactory messagingFactory,
@@ -66,7 +67,8 @@ class RequestResponseLink extends ClientEntity{
 			String linkPath,
 			String sasTokenAudienceURI,
 			String additionalAudience,
-			Map<Symbol, Object> additionalProperties)
+			Map<Symbol, Object> additionalProperties,
+			MessagingEntityType entityType)
 	{
 		final RequestResponseLink requestReponseLink = new RequestResponseLink(
 				messagingFactory,
@@ -74,7 +76,8 @@ class RequestResponseLink extends ClientEntity{
 				linkPath,
 				sasTokenAudienceURI,
 				additionalAudience,
-				additionalProperties);
+				additionalProperties,
+				entityType);
 		
 		Timer.schedule(
 				new Runnable()
@@ -162,7 +165,8 @@ class RequestResponseLink extends ClientEntity{
 			String linkPath,
 			String sasTokenAudienceURI,
 			String additionalAudience,
-			Map<Symbol, Object> additionalProperties)
+			Map<Symbol, Object> additionalProperties,
+			MessagingEntityType entityType)
 	{
 		super(linkName);
 		
@@ -179,6 +183,7 @@ class RequestResponseLink extends ClientEntity{
 		this.requestCounter = new AtomicInteger();
 		this.replyTo = UUID.randomUUID().toString();
 		this.createFuture = new CompletableFuture<RequestResponseLink>();
+		this.entityType = entityType;
 	}
 	
 	public String getLinkPath()
@@ -220,6 +225,10 @@ class RequestResponseLink extends ClientEntity{
 		Map<Symbol, Object> commonLinkProperties = new HashMap<>();
 		// ServiceBus expects timeout to be of type unsignedint
 		commonLinkProperties.put(ClientConstants.LINK_TIMEOUT_PROPERTY, UnsignedInteger.valueOf(Util.adjustServerTimeout(this.underlyingFactory.getOperationTimeout()).toMillis()));
+		if(this.entityType != null)
+		{
+			commonLinkProperties.put(ClientConstants.ENTITY_TYPE_PROPERTY, this.entityType.getIntValue());
+		}
 		if (this.additionalProperties != null) {
 			commonLinkProperties.putAll(this.additionalProperties);
 		}

--- a/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/ClientValidationTests.java
+++ b/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/ClientValidationTests.java
@@ -1,0 +1,238 @@
+package com.microsoft.azure.servicebus;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.Assert;
+
+import com.microsoft.azure.servicebus.management.EntityManager;
+import com.microsoft.azure.servicebus.management.ManagementException;
+import com.microsoft.azure.servicebus.management.QueueDescription;
+import com.microsoft.azure.servicebus.management.SubscriptionDescription;
+import com.microsoft.azure.servicebus.management.TopicDescription;
+import com.microsoft.azure.servicebus.primitives.ServiceBusException;
+
+public class ClientValidationTests
+{
+	
+	private static final String ENTITY_NAME_PREFIX = "ClientValidationTests";
+	
+	private static String queuePath;
+	private static String sessionfulQueuePath;
+	private static String topicPath;
+	private static String subscriptionPath;
+	private static String sessionfulSubscriptionPath;	
+	
+	@BeforeClass
+    public static void createEntities() throws ManagementException
+    {
+		// Create a queue, a topic and a subscription
+		queuePath = TestUtils.randomizeEntityName(ENTITY_NAME_PREFIX);
+		sessionfulQueuePath = TestUtils.randomizeEntityName(ENTITY_NAME_PREFIX);
+		topicPath = TestUtils.randomizeEntityName(ENTITY_NAME_PREFIX);
+		URI namespaceEndpointURI = TestUtils.getNamespaceEndpointURI();
+		ClientSettings managementClientSettings = TestUtils.getManagementClientSettings();
+		
+		QueueDescription queueDescription = new QueueDescription(queuePath);
+		queueDescription.setEnablePartitioning(false);
+		EntityManager.createEntity(namespaceEndpointURI, managementClientSettings, queueDescription);
+		
+		QueueDescription queueDescription2 = new QueueDescription(sessionfulQueuePath);
+		queueDescription2.setEnablePartitioning(false);
+		queueDescription2.setRequiresSession(true);
+		EntityManager.createEntity(namespaceEndpointURI, managementClientSettings, queueDescription2);
+		
+		TopicDescription topicDescription = new TopicDescription(topicPath);
+		topicDescription.setEnablePartitioning(false);
+		EntityManager.createEntity(namespaceEndpointURI, managementClientSettings, topicDescription);
+		SubscriptionDescription subDescription = new SubscriptionDescription(topicPath, TestUtils.FIRST_SUBSCRIPTION_NAME);
+		subscriptionPath = subDescription.getPath();
+        EntityManager.createEntity(namespaceEndpointURI, managementClientSettings, subDescription);
+        SubscriptionDescription subDescription2 = new SubscriptionDescription(topicPath, "subscription2");
+        subDescription2.setRequiresSession(true);
+		sessionfulSubscriptionPath = subDescription2.getPath();
+        EntityManager.createEntity(namespaceEndpointURI, managementClientSettings, subDescription2);
+    }
+	
+	@AfterClass
+	public static void deleteEntities() throws ManagementException
+	{
+		EntityManager.deleteEntity(TestUtils.getNamespaceEndpointURI(), TestUtils.getManagementClientSettings(), queuePath);
+		EntityManager.deleteEntity(TestUtils.getNamespaceEndpointURI(), TestUtils.getManagementClientSettings(), sessionfulQueuePath);
+		EntityManager.deleteEntity(TestUtils.getNamespaceEndpointURI(), TestUtils.getManagementClientSettings(), topicPath);
+	}
+	
+	@Test
+	public void testTopicClientCreationToQueue() throws InterruptedException, ServiceBusException
+	{				
+		try
+		{
+			TopicClient tc = new TopicClient(TestUtils.getNamespaceEndpointURI(), queuePath, TestUtils.getManagementClientSettings());
+			try
+			{
+				Message msg = new Message("test message");
+				tc.send(msg);
+				Assert.fail("TopicClient created to a queue which shouldn't be allowed.");
+			}
+			finally
+			{
+				tc.close();
+			}						
+		} catch (UnsupportedOperationException e) {
+			// Expected
+		}
+	}
+	
+	@Test
+	public void testQueueClientCreationToTopic() throws InterruptedException, ServiceBusException
+	{				
+		try {
+			QueueClient qc = new QueueClient(TestUtils.getNamespaceEndpointURI(), topicPath, TestUtils.getManagementClientSettings(), ReceiveMode.PEEKLOCK);
+			try {
+				Message msg = new Message("test message");
+				qc.send(msg);
+				Assert.fail("QueueClient created to a topic which shouldn't be allowed.");
+			}
+			finally {
+				qc.close();
+			}			
+		} catch (UnsupportedOperationException e) {
+			// Expected
+		}
+	}
+	
+	@Test
+	public void testQueueClientCreationToSubscription() throws InterruptedException, ServiceBusException
+	{				
+		try {
+			QueueClient qc = new QueueClient(TestUtils.getNamespaceEndpointURI(), subscriptionPath, TestUtils.getManagementClientSettings(), ReceiveMode.PEEKLOCK);
+			try
+			{
+				qc.registerMessageHandler(new IMessageHandler() {				
+					@Override
+					public CompletableFuture<Void> onMessageAsync(IMessage message) {
+						return CompletableFuture.completedFuture(null);
+					}
+					
+					@Override
+					public void notifyException(Throwable exception, ExceptionPhase phase) {					
+					}
+				});
+				Assert.fail("QueueClient created to a subscription which shouldn't be allowed.");
+			}
+			finally
+			{
+				qc.close();
+			}			
+		} catch (UnsupportedOperationException e) {
+			// Expected
+		}
+	}
+	
+	@Test
+	public void testSubscriptionClientCreationToQueue() throws InterruptedException, ServiceBusException
+	{				
+		try {
+			SubscriptionClient sc = new SubscriptionClient(TestUtils.getNamespaceEndpointURI(), queuePath, TestUtils.getManagementClientSettings(), ReceiveMode.PEEKLOCK);
+			try {
+				sc.registerMessageHandler(new IMessageHandler() {				
+					@Override
+					public CompletableFuture<Void> onMessageAsync(IMessage message) {
+						return CompletableFuture.completedFuture(null);
+					}
+					
+					@Override
+					public void notifyException(Throwable exception, ExceptionPhase phase) {					
+					}
+				});
+				Assert.fail("SubscriptionClient created to a queue which shouldn't be allowed.");
+			} finally {
+				sc.close();
+			}			
+		} catch (UnsupportedOperationException e) {
+			// Expected
+		}
+	}
+	
+	@Test
+	public void testQueueClientCreationToSessionfulSubscription() throws InterruptedException, ServiceBusException
+	{
+		try {
+			QueueClient qc = new QueueClient(TestUtils.getNamespaceEndpointURI(), sessionfulSubscriptionPath, TestUtils.getManagementClientSettings(), ReceiveMode.PEEKLOCK);
+			try {
+				final AtomicBoolean unsupportedExceptionOccured = new AtomicBoolean(false);
+				qc.registerSessionHandler(new ISessionHandler() {
+					
+					@Override
+					public CompletableFuture<Void> onMessageAsync(IMessageSession session, IMessage message) {
+						return CompletableFuture.completedFuture(null);
+					}
+					
+					@Override
+					public void notifyException(Throwable exception, ExceptionPhase phase) {
+						if(exception instanceof UnsupportedOperationException && phase == ExceptionPhase.ACCEPTSESSION)
+						{
+							unsupportedExceptionOccured.set(true);
+						}
+					}
+					
+					@Override
+					public CompletableFuture<Void> OnCloseSessionAsync(IMessageSession session) {
+						return CompletableFuture.completedFuture(null);
+					}
+				});
+				
+				Thread.sleep(1000); // Sleep for a second for the exception				
+				Assert.assertTrue("QueueClient created to a subscription which shouldn't be allowed.", unsupportedExceptionOccured.get());
+			} finally {
+				qc.close();
+			}			
+		} catch (UnsupportedOperationException e) {
+			// Expected
+		}
+	}
+	
+	@Test
+	public void testSubscriptionClientCreationToSessionfulQueue() throws InterruptedException, ServiceBusException
+	{
+		try {
+			SubscriptionClient sc = new SubscriptionClient(TestUtils.getNamespaceEndpointURI(), sessionfulQueuePath, TestUtils.getManagementClientSettings(), ReceiveMode.PEEKLOCK);
+			try {
+				final AtomicBoolean unsupportedExceptionOccured = new AtomicBoolean(false);
+				sc.registerSessionHandler(new ISessionHandler() {
+					
+					@Override
+					public CompletableFuture<Void> onMessageAsync(IMessageSession session, IMessage message) {
+						return CompletableFuture.completedFuture(null);
+					}
+					
+					@Override
+					public void notifyException(Throwable exception, ExceptionPhase phase) {
+						if(exception instanceof UnsupportedOperationException && phase == ExceptionPhase.ACCEPTSESSION)
+						{
+							unsupportedExceptionOccured.set(true);
+						}
+					}
+					
+					@Override
+					public CompletableFuture<Void> OnCloseSessionAsync(IMessageSession session) {
+						return CompletableFuture.completedFuture(null);
+					}
+				});
+				
+				Thread.sleep(1000); // Sleep for a second for the exception				
+				Assert.assertTrue("SubscriptionClient created to a queue which shouldn't be allowed.", unsupportedExceptionOccured.get());
+			} finally {
+				sc.close();
+			}
+			
+		} catch (UnsupportedOperationException e) {
+			// Expected
+		}
+	}
+	
+}

--- a/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/QueueSendReceiveTests.java
+++ b/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/QueueSendReceiveTests.java
@@ -167,9 +167,8 @@ public class QueueSendReceiveTests extends SendReceiveTests
             boolean caught = false;
             try {
                 pSender.send(message2, transaction);
-            } catch (ServiceBusException ex) {
-                caught = true;
-                Assert.assertTrue(ex.getCause() instanceof UnsupportedOperationException);
+            } catch (UnsupportedOperationException ex) {
+                caught = true;                
             }
 
             Assert.assertTrue(caught);
@@ -188,9 +187,8 @@ public class QueueSendReceiveTests extends SendReceiveTests
             try {
                 caught = false;
                 pReceiver.complete(receivedMessage2.getLockToken(), transaction);
-            } catch (ServiceBusException ex) {
+            } catch (UnsupportedOperationException ex) {
                 caught = true;
-                Assert.assertTrue(ex.getCause() instanceof UnsupportedOperationException);
             }
 
             Assert.assertTrue(caught);


### PR DESCRIPTION
Adding a property needed for additional validation to check if the type of the client being created matches the entity type. For validations like a TopicClient cannot be created to a QueueClient etc. Purely validation. Shouldn't have any impact of runtime behavior of library.
Added unit tests too.