### PR TITLE
Renaming two public methods. From getScheduledEnqueuedTime to getSche…

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/IMessage.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/IMessage.java
@@ -137,16 +137,41 @@ public interface IMessage {
      *
      * @return the instant at which the message will be enqueued in Azure Service Bus
      * @see <a href="https://docs.microsoft.com/azure/service-bus-messaging/message-sequencing">Message Sequencing and Timestamps</a> 
+     * @deprecated Replaced by {@link #getScheduledEnqueueTimeUtc()
      */
+    @Deprecated
     public Instant getScheduledEnqueuedTimeUtc();
 
     /**
      * Sets the scheduled enqueue time of this message.  
      * 
      * @param scheduledEnqueueTimeUtc the instant at which this message should be enqueued in Azure Service Bus
-     * @see #getScheduledEnqueuedTimeUtc()
+     * @see #getScheduledEnqueueTimeUtc()
+     * @deprecated Replaced by {@link #setScheduledEnqueueTimeUtc(Instant)()
      */
+    @Deprecated
     public void setScheduledEnqueuedTimeUtc(Instant scheduledEnqueueTimeUtc);
+    
+    /**
+     * Gets the scheduled enqueue time of this message. 
+     * 
+     * This value is used for delayed message availability. The message is safely added to 
+     * the queue, but is not considered active and therefore not retrievable until the 
+     * scheduled enqueue time. Mind that the message may not be activated (enqueued) at the exact given 
+     * instant; the actual activation time depends on the queue's workload and its state.
+     *
+     * @return the instant at which the message will be enqueued in Azure Service Bus
+     * @see <a href="https://docs.microsoft.com/azure/service-bus-messaging/message-sequencing">Message Sequencing and Timestamps</a> 
+     */
+    public Instant getScheduledEnqueueTimeUtc();
+
+    /**
+     * Sets the scheduled enqueue time of this message.  
+     * 
+     * @param scheduledEnqueueTimeUtc the instant at which this message should be enqueued in Azure Service Bus
+     * @see #getScheduledEnqueueTimeUtc()
+     */
+    public void setScheduledEnqueueTimeUtc(Instant scheduledEnqueueTimeUtc);
 
     /**
      * Gets the unique number assigned to a message by Service Bus.

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/Message.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/Message.java
@@ -256,15 +256,27 @@ final public class Message implements Serializable, IMessage {
 		this.replyToSessionId = replyToSessionId;		
 	}
 
+	@Deprecated
 	@Override
 	public Instant getScheduledEnqueuedTimeUtc() {
+		return this.getScheduledEnqueueTimeUtc();
+	}
+
+	@Deprecated
+	@Override
+	public void setScheduledEnqueuedTimeUtc(Instant scheduledEnqueueTimeUtc) {
+		this.setScheduledEnqueueTimeUtc(scheduledEnqueueTimeUtc);
+	}
+	
+	@Override
+	public Instant getScheduledEnqueueTimeUtc() {
 		return this.scheduledEnqueueTimeUtc;
 	}
 
 	@Override
-	public void setScheduledEnqueuedTimeUtc(Instant scheduledEnqueueTimeUtc) {
+	public void setScheduledEnqueueTimeUtc(Instant scheduledEnqueueTimeUtc) {
 		this.scheduledEnqueueTimeUtc = scheduledEnqueueTimeUtc;		
-	}	
+	}
 
 	@Override
 	public String getPartitionKey() {
@@ -313,5 +325,4 @@ final public class Message implements Serializable, IMessage {
 	{
 		this.deliveryTag = deliveryTag;
 	}
-	
 }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageConverter.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageConverter.java
@@ -50,9 +50,9 @@ class MessageConverter
 		amqpMessage.setGroupId(brokeredMessage.getSessionId());
 		
 		Map<Symbol, Object> messageAnnotationsMap = new HashMap<Symbol, Object>();
-		if(brokeredMessage.getScheduledEnqueuedTimeUtc() != null)
+		if(brokeredMessage.getScheduledEnqueueTimeUtc() != null)
 		{
-			messageAnnotationsMap.put(Symbol.valueOf(ClientConstants.SCHEDULEDENQUEUETIMENAME), Date.from(brokeredMessage.getScheduledEnqueuedTimeUtc()));
+			messageAnnotationsMap.put(Symbol.valueOf(ClientConstants.SCHEDULEDENQUEUETIMENAME), Date.from(brokeredMessage.getScheduledEnqueueTimeUtc()));
 		}
 		
 		if(!StringUtil.isNullOrEmpty(brokeredMessage.getPartitionKey()))
@@ -163,7 +163,7 @@ class MessageConverter
 							brokeredMessage.setEnqueuedTimeUtc(((Date)entry.getValue()).toInstant());
 							break;
 						case ClientConstants.SCHEDULEDENQUEUETIMENAME:
-	                        brokeredMessage.setScheduledEnqueuedTimeUtc(((Date)entry.getValue()).toInstant());
+	                        brokeredMessage.setScheduledEnqueueTimeUtc(((Date)entry.getValue()).toInstant());
 	                        break;
 	                    case ClientConstants.SEQUENCENUBMERNAME:
 	                        brokeredMessage.setSequenceNumber((long)entry.getValue());

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
@@ -196,7 +196,7 @@ final class MessageSender extends InitializableEntity implements IMessageSender 
 
     @Override
     public CompletableFuture<Long> scheduleMessageAsync(IMessage message, Instant scheduledEnqueueTimeUtc, TransactionContext transaction) {
-        message.setScheduledEnqueuedTimeUtc(scheduledEnqueueTimeUtc);
+        message.setScheduledEnqueueTimeUtc(scheduledEnqueueTimeUtc);
         org.apache.qpid.proton.message.Message amqpMessage = MessageConverter.convertBrokeredMessageToAmqpMessage((Message) message);
         return this.internalSender.scheduleMessageAsync(
                 new org.apache.qpid.proton.message.Message[]{amqpMessage},


### PR DESCRIPTION
From getScheduledEnqueuedTime to getScheduledEnqueueTime.

Similarly for set. They were mistakenly kept like that in the first release.