### PR TITLE
recognize "SharedAccessSignature" key name in ConnectionStringBuilder

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ConnectionStringBuilder.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ConnectionStringBuilder.java
@@ -10,8 +10,6 @@ import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.regex.*;
 
-import com.microsoft.azure.servicebus.security.SharedAccessSignatureTokenProvider;
-
 /**
  * This class can be used to construct a connection string which can establish communication with ServiceBus entities.
  * It can also be used to perform basic validation on an existing connection string.
@@ -48,7 +46,7 @@ public class ConnectionStringBuilder
 	private final static String ENDPOINT_CONFIG_NAME = "Endpoint";
 	private final static String SHARED_ACCESS_KEY_NAME_CONFIG_NAME = "SharedAccessKeyName";
 	private final static String SHARED_ACCESS_KEY_CONFIG_NAME = "SharedAccessKey";
-	private final static String DOT_NET_SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME = "SharedAccessSignature";
+	private final static String ALTERNATE_SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME = "SharedAccessSignature";
 	private final static String SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME = "SharedAccessSignatureToken";
 	private final static String ENTITY_PATH_CONFIG_NAME = "EntityPath";
 	private final static String OPERATION_TIMEOUT_CONFIG_NAME = "OperationTimeout";
@@ -58,7 +56,7 @@ public class ConnectionStringBuilder
 
 	private static final String ALL_KEY_ENUMERATE_REGEX = "(" + HOSTNAME_CONFIG_NAME + "|" +  ENDPOINT_CONFIG_NAME + "|" + SHARED_ACCESS_KEY_NAME_CONFIG_NAME
 			+ "|" + SHARED_ACCESS_KEY_CONFIG_NAME + "|"  + SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME + "|" + ENTITY_PATH_CONFIG_NAME + "|" + OPERATION_TIMEOUT_CONFIG_NAME
-			+ "|" + RETRY_POLICY_CONFIG_NAME + "|" + DOT_NET_SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME + ")";
+			+ "|" + RETRY_POLICY_CONFIG_NAME + "|" + ALTERNATE_SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME + ")";
 
 	private static final String KEYS_WITH_DELIMITERS_REGEX = KEY_VALUE_PAIR_DELIMITER + ALL_KEY_ENUMERATE_REGEX	+ KEY_VALUE_SEPARATOR;
 
@@ -456,10 +454,10 @@ public class ConnectionStringBuilder
                 this.sharedAccessSingatureToken = values[valueIndex];
                 this.sharedAccessSignatureTokenKeyName = SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME;
             }
-			else if(key.equalsIgnoreCase(DOT_NET_SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME))
+			else if(key.equalsIgnoreCase(ALTERNATE_SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME))
             {
                 this.sharedAccessSingatureToken = values[valueIndex];
-                this.sharedAccessSignatureTokenKeyName = DOT_NET_SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME;
+                this.sharedAccessSignatureTokenKeyName = ALTERNATE_SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME;
             }
 			else if (key.equalsIgnoreCase(ENTITY_PATH_CONFIG_NAME))
 			{

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ConnectionStringBuilder.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ConnectionStringBuilder.java
@@ -48,6 +48,7 @@ public class ConnectionStringBuilder
 	private final static String ENDPOINT_CONFIG_NAME = "Endpoint";
 	private final static String SHARED_ACCESS_KEY_NAME_CONFIG_NAME = "SharedAccessKeyName";
 	private final static String SHARED_ACCESS_KEY_CONFIG_NAME = "SharedAccessKey";
+	private final static String DOT_NET_SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME = "SharedAccessSignature";
 	private final static String SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME = "SharedAccessSignatureToken";
 	private final static String ENTITY_PATH_CONFIG_NAME = "EntityPath";
 	private final static String OPERATION_TIMEOUT_CONFIG_NAME = "OperationTimeout";
@@ -57,7 +58,7 @@ public class ConnectionStringBuilder
 
 	private static final String ALL_KEY_ENUMERATE_REGEX = "(" + HOSTNAME_CONFIG_NAME + "|" +  ENDPOINT_CONFIG_NAME + "|" + SHARED_ACCESS_KEY_NAME_CONFIG_NAME
 			+ "|" + SHARED_ACCESS_KEY_CONFIG_NAME + "|"  + SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME + "|" + ENTITY_PATH_CONFIG_NAME + "|" + OPERATION_TIMEOUT_CONFIG_NAME
-			+ "|" + RETRY_POLICY_CONFIG_NAME + ")";
+			+ "|" + RETRY_POLICY_CONFIG_NAME + "|" + DOT_NET_SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME + ")";
 
 	private static final String KEYS_WITH_DELIMITERS_REGEX = KEY_VALUE_PAIR_DELIMITER + ALL_KEY_ENUMERATE_REGEX	+ KEY_VALUE_SEPARATOR;
 
@@ -66,6 +67,7 @@ public class ConnectionStringBuilder
 	private String sharedAccessKeyName;
 	private String sharedAccessKey;
 	private String sharedAccessSingatureToken;
+	private String sharedAccessSignatureTokenKeyName;
 	private String entityPath;
 	private Duration operationTimeout;
 	private RetryPolicy retryPolicy;
@@ -340,7 +342,7 @@ public class ConnectionStringBuilder
 			
 			if (!StringUtil.isNullOrWhiteSpace(this.sharedAccessSingatureToken))
             {
-                connectionStringBuilder.append(String.format(Locale.US, "%s%s%s", SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME,
+                connectionStringBuilder.append(String.format(Locale.US, "%s%s%s", sharedAccessSignatureTokenKeyName,
                         KEY_VALUE_SEPARATOR, this.sharedAccessSingatureToken));
             }
 
@@ -452,6 +454,12 @@ public class ConnectionStringBuilder
 			else if(key.equalsIgnoreCase(SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME))
             {
                 this.sharedAccessSingatureToken = values[valueIndex];
+                this.sharedAccessSignatureTokenKeyName = SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME;
+            }
+			else if(key.equalsIgnoreCase(DOT_NET_SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME))
+            {
+                this.sharedAccessSingatureToken = values[valueIndex];
+                this.sharedAccessSignatureTokenKeyName = DOT_NET_SHARED_ACCESS_SIGNATURE_TOKEN_CONFIG_NAME;
             }
 			else if (key.equalsIgnoreCase(ENTITY_PATH_CONFIG_NAME))
 			{

--- a/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/primitives/ConnectionStringBuilderTests.java
+++ b/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/primitives/ConnectionStringBuilderTests.java
@@ -1,0 +1,18 @@
+package com.microsoft.azure.servicebus.primitives;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConnectionStringBuilderTests {
+
+    @Test
+    public void test() {
+        String connectionString = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessSignature=SharedAccessSignature sr=amqp%3A%2F%2test.servicebus.windows.net%2topic";
+        ConnectionStringBuilder builder = new ConnectionStringBuilder(connectionString);
+
+        assertEquals("SharedAccessSignature sr=amqp%3A%2F%2test.servicebus.windows.net%2topic", builder.getSharedAccessSignatureToken());
+        assertEquals(connectionString, builder.toString());
+    }
+
+}


### PR DESCRIPTION
## Description
<!--
Please add an informative description that covers the changes made by the pull request.

If applicable, reference the bug/issue that this pull request fixes here.
-->
recognize "SharedAccessSignature" as the shared access token key name in ConnectionStringBuilder

resolves https://github.com/Azure/azure-service-bus-java/issues/249


This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.