### PR TITLE
Adding link name to warning and error traces.

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
@@ -643,14 +643,14 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
             
 			if (this.linkOpen != null && !this.linkOpen.getWork().isDone())
 			{
-			    TRACE_LOGGER.error("Opening receive link to '{}' failed.", this.receivePath, exception);
+			    TRACE_LOGGER.error("Opening receive link '{}' to '{}' failed.", this.receiveLink.getName(), this.receivePath, exception);
 				this.setClosed();
 				ExceptionUtil.completeExceptionally(this.linkOpen.getWork(), exception, this, true);
 			}
 			
 			if(this.receiveLinkReopenFuture != null && !this.receiveLinkReopenFuture.isDone())
             {
-			    TRACE_LOGGER.warn("Opening receive link to '{}' failed.", this.receivePath, exception);
+			    TRACE_LOGGER.warn("Opening receive link '{}' to '{}' failed.", this.receiveLink.getName(), this.receivePath, exception);
 			    AsyncUtil.completeFutureExceptionally(this.receiveLinkReopenFuture, exception);
 			    if(this.isSessionReceiver && (exception instanceof SessionLockLostException || exception instanceof SessionCannotBeLockedException))
                 {
@@ -832,7 +832,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 		}
 		else
 		{
-		    TRACE_LOGGER.warn("Receive link to '{}', sessionId '{}' closed with error.", this.receivePath, this.sessionId, exception);
+		    TRACE_LOGGER.warn("Receive link '{}' to '{}', sessionId '{}' closed with error.", this.receiveLink.getName(), this.receivePath, this.sessionId, exception);
 			this.lastKnownLinkError = exception;
 			if ((this.linkOpen != null && !this.linkOpen.getWork().isDone()) ||
 			     (this.receiveLinkReopenFuture !=null && !receiveLinkReopenFuture.isDone()))
@@ -866,7 +866,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 	                            .getNextRetryInterval(this.getClientId(), exception, workItem.getTimeoutTracker().remaining());
 	                    if (nextRetryInterval != null)
 	                    {
-	                        TRACE_LOGGER.info("Receive link to '{}', sessionId '{}' will be reopened after '{}'", this.receivePath, this.sessionId, nextRetryInterval);
+	                        TRACE_LOGGER.info("Receive link '{}' to '{}', sessionId '{}' will be reopened after '{}'", this.receiveLink.getName(), this.receivePath, this.sessionId, nextRetryInterval);
 	                        Timer.schedule(() -> {CoreMessageReceiver.this.ensureLinkIsOpen();}, nextRetryInterval, TimerType.OneTimeRun);
 	                    }
 	                }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageSender.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageSender.java
@@ -466,14 +466,14 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 		    this.cancelSASTokenRenewTimer();
 			if (!this.linkFirstOpen.isDone())
 			{
-			    TRACE_LOGGER.error("Opening send link to '{}' failed", this.sendPath, completionException);
+			    TRACE_LOGGER.error("Opening send link '{}' to '{}' failed", this.sendLink.getName(), this.sendPath, completionException);
 				this.setClosed();				
 				ExceptionUtil.completeExceptionally(this.linkFirstOpen, completionException, this, true);
 			}
 			
 			if(this.sendLinkReopenFuture != null && !this.sendLinkReopenFuture.isDone())
             {
-			    TRACE_LOGGER.warn("Opening send link to '{}' failed", this.sendPath, completionException);
+			    TRACE_LOGGER.warn("Opening send link '{}' to '{}' failed", this.sendLink.getName(), this.sendPath, completionException);
                 AsyncUtil.completeFutureExceptionally(this.sendLinkReopenFuture, completionException);
             }
 		}
@@ -514,7 +514,7 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 			if (completionException != null &&
 					(!(completionException instanceof ServiceBusException) || !((ServiceBusException) completionException).getIsTransient()))
 			{
-			    TRACE_LOGGER.warn("Send link to '{}' closed. Failing all pending send requests.", this.sendPath);
+			    TRACE_LOGGER.warn("Send link '{}' to '{}' closed. Failing all pending send requests.", this.sendLink.getName(), this.sendPath);
 				this.clearAllPendingSendsWithException(completionException);
 			}
 			else
@@ -528,7 +528,7 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 						final Duration nextRetryInterval = this.retryPolicy.getNextRetryInterval(this.getClientId(), completionException, tracker.remaining());
 						if (nextRetryInterval != null)
 						{
-						    TRACE_LOGGER.warn("Send link to '{}' closed. Will retry link creation after '{}'.", this.sendPath, nextRetryInterval);
+						    TRACE_LOGGER.warn("Send link '{}' to '{}' closed. Will retry link creation after '{}'.", this.sendLink.getName(), this.sendPath, nextRetryInterval);
 						    Timer.schedule(() -> {CoreMessageSender.this.ensureLinkIsOpen();}, nextRetryInterval, TimerType.OneTimeRun);
 						}
 					}

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
@@ -610,7 +610,7 @@ class RequestResponseLink extends ClientEntity{
 			}
 			else
 			{
-			    TRACE_LOGGER.error("Opening internal receive link of requestresponselink to {} failed.", parent.linkPath, completionException);
+			    TRACE_LOGGER.error("Opening internal receive link '{}' of requestresponselink to {} failed.", this.receiveLink.getName(), this.parent.linkPath, completionException);
 			    this.setClosed();
 			    this.closeFuture.complete(null);
 				this.openFuture.completeExceptionally(completionException);
@@ -628,12 +628,12 @@ class RequestResponseLink extends ClientEntity{
 			{
 				if(!this.closeFuture.isDone())
 				{
-				    TRACE_LOGGER.error("Closing internal receive link of requestresponselink to {} failed.", parent.linkPath, exception);
+				    TRACE_LOGGER.error("Closing internal receive link '{}' of requestresponselink to {} failed.", this.receiveLink.getName(), this.parent.linkPath, exception);
 					this.closeFuture.completeExceptionally(exception);
 				}
 			}
 			
-			TRACE_LOGGER.warn("Internal receive link of requestresponselink to '{}' encountered error.", this.parent.linkPath, exception);
+			TRACE_LOGGER.warn("Internal receive link '{}' of requestresponselink to '{}' encountered error.", this.receiveLink.getName(), this.parent.linkPath, exception);
 			this.parent.underlyingFactory.deregisterForConnectionError(this.receiveLink);
 			if(this.parent.amqpSender.sendLink != null)
             {
@@ -658,7 +658,7 @@ class RequestResponseLink extends ClientEntity{
 					else
 					{
 						Exception exception = ExceptionUtil.toException(condition);
-						TRACE_LOGGER.error("Closing internal receive link of requestresponselink to {} failed.", parent.linkPath, exception);
+						TRACE_LOGGER.error("Closing internal receive link '{}' of requestresponselink to {} failed.", this.receiveLink.getName(), this.parent.linkPath, exception);
 						this.closeFuture.completeExceptionally(exception);
 					}
 				}
@@ -674,7 +674,7 @@ class RequestResponseLink extends ClientEntity{
 					}
 					else
 					{
-					    TRACE_LOGGER.warn("Internal receive link of requestresponselink to '{}' closed with error.", this.parent.linkPath, exception);
+					    TRACE_LOGGER.warn("Internal receive link '{}' of requestresponselink to '{}' closed with error.", this.receiveLink.getName(), this.parent.linkPath, exception);
 					    this.parent.underlyingFactory.deregisterForConnectionError(this.receiveLink);
 					    if(this.parent.amqpSender.sendLink != null)
 			            {
@@ -819,7 +819,7 @@ class RequestResponseLink extends ClientEntity{
 			}
 			else
 			{
-			    TRACE_LOGGER.error("Opening internal send link of requestresponselink to {} failed.", parent.linkPath, completionException);
+			    TRACE_LOGGER.error("Opening internal send link '{}' of requestresponselink to {} failed.", this.sendLink.getName(), this.parent.linkPath, completionException);
 			    this.setClosed();
 			    this.closeFuture.complete(null);
 				this.openFuture.completeExceptionally(completionException);
@@ -837,12 +837,12 @@ class RequestResponseLink extends ClientEntity{
 			{
 				if(!this.closeFuture.isDone())
 				{
-				    TRACE_LOGGER.error("Closing internal send link of requestresponselink to {} failed.", parent.linkPath, exception);
+				    TRACE_LOGGER.error("Closing internal send link '{}' of requestresponselink to {} failed.", this.sendLink.getName(), this.parent.linkPath, exception);
 					this.closeFuture.completeExceptionally(exception);
 				}
 			}
 			
-			TRACE_LOGGER.warn("Internal send link of requestresponselink to '{}' encountered error.", this.parent.linkPath, exception);
+			TRACE_LOGGER.warn("Internal send link '{}' of requestresponselink to '{}' encountered error.", this.sendLink.getName(), this.parent.linkPath, exception);
 			this.parent.underlyingFactory.deregisterForConnectionError(this.sendLink);
 			if(this.parent.amqpReceiver.receiveLink != null)
             {
@@ -861,13 +861,13 @@ class RequestResponseLink extends ClientEntity{
 				{
 					if(condition == null || condition.getCondition() == null)
 					{
-					    TRACE_LOGGER.info("Closed internal send link of requestresponselink to {}", parent.linkPath);
+					    TRACE_LOGGER.info("Closed internal send link of requestresponselink to {}", this.parent.linkPath);
 						this.closeFuture.complete(null);
 					}
 					else
 					{
 						Exception exception = ExceptionUtil.toException(condition);
-						TRACE_LOGGER.error("Closing internal send link of requestresponselink to {} failed.", parent.linkPath, exception);
+						TRACE_LOGGER.error("Closing internal send link '{}' of requestresponselink to {} failed.", this.sendLink.getName(), this.parent.linkPath, exception);
 						this.closeFuture.completeExceptionally(exception);
 					}
 				}
@@ -883,7 +883,7 @@ class RequestResponseLink extends ClientEntity{
 					}
 					else
 					{
-					    TRACE_LOGGER.warn("Internal send link of requestresponselink to '{}' closed with error.", this.parent.linkPath, exception);
+					    TRACE_LOGGER.warn("Internal send link '{}' of requestresponselink to '{}' closed with error.", this.sendLink.getName(), this.parent.linkPath, exception);
 					    this.parent.underlyingFactory.deregisterForConnectionError(this.sendLink);
 					    
 					    if(this.parent.amqpReceiver.receiveLink != null)


### PR DESCRIPTION
Link name will have the gateway number and that info makes it much easier to quickly search through service log.