### PR TITLE
Change to not use ForkJoinPool for SdK internal operations

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/IMessageAndSessionPump.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/IMessageAndSessionPump.java
@@ -6,6 +6,9 @@ package com.microsoft.azure.servicebus;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.jar.JarException;
 
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 
@@ -16,41 +19,96 @@ interface IMessageAndSessionPump {
 
     /**
      * Receive messages continuously from the entity. Registers a message handler and begins a new thread to receive messages.
+     * IMessageHandler methods are executed on java.util.concurrent.commonPool()
      *
      * @param handler The {@link IMessageHandler} instance
      * @throws InterruptedException if the current thread was interrupted while waiting
      * @throws ServiceBusException  if register failed
+     * @deprecated Use {@link #registerMessageHandler(IMessageHandler, ExecutorService)}
      */
+	@Deprecated
     public void registerMessageHandler(IMessageHandler handler) throws InterruptedException, ServiceBusException;
+    
+    /**
+     * Receive messages continuously from the entity. Registers a message handler and begins a new thread to receive messages.
+     * IMessageHandler methods are executed on the passed executor service.
+     *
+     * @param handler The {@link IMessageHandler} instance
+     * @param executorService ExecutorService which is used to execute {@link IMessageHandler} methods. If there are 
+     * @throws InterruptedException if the current thread was interrupted while waiting
+     * @throws ServiceBusException  if register failed
+     */
+    public void registerMessageHandler(IMessageHandler handler, ExecutorService executorService) throws InterruptedException, ServiceBusException;
 
     /**
      * Receive messages continuously from the entity. Registers a message handler and begins a new thread to receive messages.
+     * IMessageHandler methods are executed on java.util.concurrent.commonPool()
      *
      * @param handler        The {@link IMessageHandler} instance
      * @param handlerOptions {@link MessageHandlerOptions}
      * @throws InterruptedException if the current thread was interrupted while waiting
      * @throws ServiceBusException  if register failed
      */
+    @Deprecated
     public void registerMessageHandler(IMessageHandler handler, MessageHandlerOptions handlerOptions) throws InterruptedException, ServiceBusException;
+    
+    /**
+     * Receive messages continuously from the entity. Registers a message handler and begins a new thread to receive messages.
+     * IMessageHandler methods are executed on the passed executor service.
+     *
+     * @param handler        The {@link IMessageHandler} instance
+     * @param handlerOptions {@link MessageHandlerOptions}
+     * @param executorService ExecutorService which is used to execute {@link IMessageHandler} methods
+     * @throws InterruptedException if the current thread was interrupted while waiting
+     * @throws ServiceBusException  if register failed
+     */
+    public void registerMessageHandler(IMessageHandler handler, MessageHandlerOptions handlerOptions, ExecutorService executorService) throws InterruptedException, ServiceBusException;
 
     /**
-     * Receive session messages continously from the queue. Registers a message handler and begins a new thread to receive session-messages.
-     *
+     * Receive session messages continuously from the queue. Registers a message handler and begins a new thread to receive session-messages.
+     * ISessionHandler methods are executed on java.util.concurrent.commonPool()
+     * 
      * @param handler The {@link ISessionHandler} instance
      * @throws InterruptedException if the current thread was interrupted while waiting
      * @throws ServiceBusException  if register failed
      */
+    @Deprecated
     public void registerSessionHandler(ISessionHandler handler) throws InterruptedException, ServiceBusException;
+    
+    /**
+     * Receive session messages continuously from the queue. Registers a message handler and begins a new thread to receive session-messages.
+     * ISessionHandler methods are executed on the passed executor service.
+     *
+     * @param handler The {@link ISessionHandler} instance
+     * @param executorService ExecutorService which is used to execute {@link ISessionHandler} methods
+     * @throws InterruptedException if the current thread was interrupted while waiting
+     * @throws ServiceBusException  if register failed
+     */
+    public void registerSessionHandler(ISessionHandler handler, ExecutorService executorService) throws InterruptedException, ServiceBusException;
 
     /**
-     * Receive session messages continously from the queue. Registers a message handler and begins a new thread to receive session-messages.
+     * Receive session messages continuously from the queue. Registers a message handler and begins a new thread to receive session-messages.
+     * ISessionHandler methods are executed on java.util.concurrent.commonPool()
      *
      * @param handler        The {@link ISessionHandler} instance
      * @param handlerOptions {@link SessionHandlerOptions}
      * @throws InterruptedException if the current thread was interrupted while waiting
      * @throws ServiceBusException  if register failed
      */
+    @Deprecated
     public void registerSessionHandler(ISessionHandler handler, SessionHandlerOptions handlerOptions) throws InterruptedException, ServiceBusException;
+    
+    /**
+     * Receive session messages continuously from the queue. Registers a message handler and begins a new thread to receive session-messages.
+     * ISessionHandler methods are executed on the passed executor service.
+     *
+     * @param handler        The {@link ISessionHandler} instance
+     * @param handlerOptions {@link SessionHandlerOptions}
+     * @param executorService ExecutorService which is used to execute {@link ISessionHandler} methods
+     * @throws InterruptedException if the current thread was interrupted while waiting
+     * @throws ServiceBusException  if register failed
+     */
+    public void registerSessionHandler(ISessionHandler handler, SessionHandlerOptions handlerOptions, ExecutorService executorService) throws InterruptedException, ServiceBusException;
 
     /**
      * Abandon {@link Message} with lock token. This will make the message available again for processing. Abandoning a message will increase the delivery count on the message

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageAndSessionPump.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageAndSessionPump.java
@@ -9,6 +9,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledFuture;
 
 import org.slf4j.Logger;
@@ -32,6 +34,7 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
     private static final Duration MAXIMUM_RENEW_LOCK_BUFFER = Duration.ofSeconds(10);
     private static final Duration SLEEP_DURATION_ON_ACCEPT_SESSION_EXCEPTION = Duration.ofMinutes(1);
     private static final int UNSET_PREFETCH_COUNT = -1; // Means prefetch count not set
+    private static final CompletableFuture<Void> COMPLETED_FUTURE = CompletableFuture.completedFuture(null);
 
     private final ConcurrentHashMap<String, IMessageSession> openSessions;
     private final MessagingFactory factory;
@@ -46,6 +49,7 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
     private MessageHandlerOptions messageHandlerOptions;
     private SessionHandlerOptions sessionHandlerOptions;
     private int prefetchCount;
+    private ExecutorService customCodeExecutor;
 
     public MessageAndSessionPump(MessagingFactory factory, String entityPath, MessagingEntityType entityType, ReceiveMode receiveMode) {
         super(StringUtil.getShortRandomString());
@@ -55,6 +59,7 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
         this.receiveMode = receiveMode;
         this.openSessions = new ConcurrentHashMap<>();
         this.prefetchCount = UNSET_PREFETCH_COUNT;
+        this.customCodeExecutor = ForkJoinPool.commonPool(); // Until we accept a threadpool from the customer
     }
 
     @Override
@@ -137,7 +142,7 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
                         CompletableFuture<Void> onMessageFuture;
                         try {
                             TRACE_LOGGER.debug("Invoking onMessage with message containing sequence number '{}'", message.getSequenceNumber());
-                            onMessageFuture = this.messageHandler.onMessageAsync(message);
+                            onMessageFuture = COMPLETED_FUTURE.thenComposeAsync((v) -> this.messageHandler.onMessageAsync(message), this.customCodeExecutor);
                         } catch (Exception onMessageSyncEx) {
                             TRACE_LOGGER.error("Invocation of onMessage with message containing sequence number '{}' threw unexpected exception", message.getSequenceNumber(), onMessageSyncEx);
                             onMessageFuture = new CompletableFuture<Void>();
@@ -147,7 +152,7 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
                         // Some clients are returning null from the call
                         if(onMessageFuture == null)
                         {
-                            onMessageFuture = CompletableFuture.completedFuture(null);
+                            onMessageFuture = COMPLETED_FUTURE;
                         }
 
                         onMessageFuture.handleAsync((v, onMessageEx) -> {
@@ -194,19 +199,19 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
                                     }
                                     this.receiveAndPumpMessage();
                                     return null;
-                                });
+                                }, MessagingFactory.INTERNAL_THREAD_POOL);
                             } else {
                                 this.receiveAndPumpMessage();
                             }
 
                             return null;
-                        });
+                        }, MessagingFactory.INTERNAL_THREAD_POOL);
                     }
 
                 }
 
                 return null;
-            });
+            }, MessagingFactory.INTERNAL_THREAD_POOL);
         }
     }
 
@@ -254,7 +259,7 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
                 }
 
                 return null;
-            });
+            }, MessagingFactory.INTERNAL_THREAD_POOL);
         }
     }
 
@@ -271,7 +276,7 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
                         if (shouldRetry) {
                             this.receiveFromSessionAndPumpMessage(sessionTracker);
                         }
-                    });
+                    }, MessagingFactory.INTERNAL_THREAD_POOL);
                 } else {
                     if (message == null) {
                         TRACE_LOGGER.debug("Receive from from session '{}' on entity '{}' returned no messages.", session.getSessionId(), this.entityPath);
@@ -279,7 +284,7 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
                             if (shouldRetry) {
                                 this.receiveFromSessionAndPumpMessage(sessionTracker);
                             }
-                        });
+                        }, MessagingFactory.INTERNAL_THREAD_POOL);
                     } else {
                         TRACE_LOGGER.trace("Message with sequence number '{}' received from session '{}' on entity '{}'.", message.getSequenceNumber(), session.getSessionId(), this.entityPath);
                         sessionTracker.notifyMessageReceived();
@@ -293,7 +298,7 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
                         TRACE_LOGGER.debug("Invoking onMessage with message containing sequence number '{}'", message.getSequenceNumber());
                         CompletableFuture<Void> onMessageFuture;
                         try {
-                            onMessageFuture = this.sessionHandler.onMessageAsync(session, message);
+                            onMessageFuture = COMPLETED_FUTURE.thenComposeAsync((v) -> this.sessionHandler.onMessageAsync(session, message), this.customCodeExecutor);
                         } catch (Exception onMessageSyncEx) {
                             TRACE_LOGGER.error("Invocation of onMessage with message containing sequence number '{}' threw unexpected exception", message.getSequenceNumber(), onMessageSyncEx);
                             onMessageFuture = new CompletableFuture<Void>();
@@ -303,7 +308,7 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
                         // Some clients are returning null from the call
                         if(onMessageFuture == null)
                         {
-                            onMessageFuture = CompletableFuture.completedFuture(null);
+                            onMessageFuture = COMPLETED_FUTURE;
                         }
                         
                         onMessageFuture.handleAsync((v, onMessageEx) -> {
@@ -347,19 +352,19 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
                                     }
                                     this.receiveFromSessionAndPumpMessage(sessionTracker);
                                     return null;
-                                });
+                                }, MessagingFactory.INTERNAL_THREAD_POOL);
                             } else {
                                 this.receiveFromSessionAndPumpMessage(sessionTracker);
                             }
 
                             return null;
-                        });
+                        }, MessagingFactory.INTERNAL_THREAD_POOL);
                     }
 
                 }
 
                 return null;
-            });
+            }, MessagingFactory.INTERNAL_THREAD_POOL);
         }
     }
 
@@ -426,7 +431,7 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
                         TimerType.OneTimeRun);
                 CompletableFuture<Void> onCloseFuture;
                 try {
-                    onCloseFuture = this.messageAndSessionPump.sessionHandler.OnCloseSessionAsync(session);
+                    onCloseFuture = COMPLETED_FUTURE.thenComposeAsync((v) -> this.messageAndSessionPump.sessionHandler.OnCloseSessionAsync(session), this.messageAndSessionPump.customCodeExecutor);
                 } catch (Exception onCloseSyncEx) {
                     TRACE_LOGGER.error("Invocation of onCloseSession on session '{}' threw unexpected exception", this.session.getSessionId(), onCloseSyncEx);
                     onCloseFuture = new CompletableFuture<Void>();
@@ -436,7 +441,7 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
                 // Some clients are returning null from the call
                 if(onCloseFuture == null)
                 {
-                    onCloseFuture = CompletableFuture.completedFuture(null);
+                    onCloseFuture = COMPLETED_FUTURE;
                 }
 
                 onCloseFuture.handleAsync((v, onCloseEx) -> {
@@ -462,9 +467,9 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
                         this.messageAndSessionPump.openSessions.remove(this.session.getSessionId());
                         this.messageAndSessionPump.acceptSessionAndPumpMessages();
                         return null;
-                    });
+                    }, MessagingFactory.INTERNAL_THREAD_POOL);
                     return null;
-                });
+                }, MessagingFactory.INTERNAL_THREAD_POOL);
 
             }
 
@@ -558,7 +563,7 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
                             }
 
                             return null;
-                        });
+                        }, MessagingFactory.INTERNAL_THREAD_POOL);
                     }, renewInterval, TimerType.OneTimeRun);
                 }
             }
@@ -613,7 +618,7 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
                             }
 
                             return null;
-                        });
+                        }, MessagingFactory.INTERNAL_THREAD_POOL);
                     }, renewInterval, TimerType.OneTimeRun);
                 }
             }
@@ -735,13 +740,13 @@ class MessageAndSessionPump extends InitializableEntity implements IMessageAndSe
     // Don't notify handler if the pump is already closed
     private void notifyExceptionToSessionHandler(Throwable ex, ExceptionPhase phase) {
         if (!(ex instanceof IllegalStateException && this.getIsClosingOrClosed())) {
-            this.sessionHandler.notifyException(ex, phase);
+            this.customCodeExecutor.execute(() -> {this.sessionHandler.notifyException(ex, phase);});
         }
     }
 
     private void notifyExceptionToMessageHandler(Throwable ex, ExceptionPhase phase) {
         if (!(ex instanceof IllegalStateException && this.getIsClosingOrClosed())) {
-            this.messageHandler.notifyException(ex, phase);
+        	this.customCodeExecutor.execute(() -> {this.messageHandler.notifyException(ex, phase);});            
         }
     }
 

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageBrowser.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageBrowser.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.microsoft.azure.servicebus.primitives.MessagingFactory;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 
 final class MessageBrowser implements IMessageBrowser {
@@ -66,7 +67,7 @@ final class MessageBrowser implements IMessageBrowser {
                 iterator.remove();
             }
             return message;
-        });
+        }, MessagingFactory.INTERNAL_THREAD_POOL);
     }
 
     @Override
@@ -106,6 +107,6 @@ final class MessageBrowser implements IMessageBrowser {
             }
 
             return convertedMessages;
-        });
+        }, MessagingFactory.INTERNAL_THREAD_POOL);
     }
 }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
@@ -141,7 +141,7 @@ class MessageReceiver extends InitializableEntity implements IMessageReceiver, I
                                 this.messagingFactory.closeAsync();
                             }
                         }
-                    });
+                    }, MessagingFactory.INTERNAL_THREAD_POOL);
                 } else {
                     acceptReceiverFuture = CompletableFuture.completedFuture(null);
                 }
@@ -156,8 +156,8 @@ class MessageReceiver extends InitializableEntity implements IMessageReceiver, I
                     } else {
                         TRACE_LOGGER.info("Created MessageBrowser to entity '{}'", this.entityPath);
                     }
-                });
-            });
+                }, MessagingFactory.INTERNAL_THREAD_POOL);
+            }, MessagingFactory.INTERNAL_THREAD_POOL);
         }
     }
 
@@ -368,7 +368,7 @@ class MessageReceiver extends InitializableEntity implements IMessageReceiver, I
                 return null;
             else
                 return MessageConverter.convertAmqpMessageToBrokeredMessage(c.toArray(new MessageWithDeliveryTag[0])[0]);
-        });
+        }, MessagingFactory.INTERNAL_THREAD_POOL);
     }
 
     @Override
@@ -386,7 +386,7 @@ class MessageReceiver extends InitializableEntity implements IMessageReceiver, I
                 return null;
             else
                 return convertAmqpMessagesWithDeliveryTagsToBrokeredMessages(c);
-        });
+        }, MessagingFactory.INTERNAL_THREAD_POOL);
     }
 
     @Override
@@ -401,7 +401,7 @@ class MessageReceiver extends InitializableEntity implements IMessageReceiver, I
                 return null;
             else
                 return c.toArray(new Message[0])[0];
-        });
+        }, MessagingFactory.INTERNAL_THREAD_POOL);
     }
 
     @Override
@@ -415,7 +415,7 @@ class MessageReceiver extends InitializableEntity implements IMessageReceiver, I
                 return null;
             else
                 return convertAmqpMessagesWithLockTokensToBrokeredMessages(c);
-        });
+        }, MessagingFactory.INTERNAL_THREAD_POOL);
     }
 
     @Override
@@ -443,7 +443,7 @@ class MessageReceiver extends InitializableEntity implements IMessageReceiver, I
                 } else {
                     return CompletableFuture.completedFuture(null);
                 }
-            });
+            }, MessagingFactory.INTERNAL_THREAD_POOL);
         } else {
             return CompletableFuture.completedFuture(null);
         }
@@ -563,7 +563,8 @@ class MessageReceiver extends InitializableEntity implements IMessageReceiver, I
                         }
                     }
                     return newLockedUntilTimes;
-                }
+                },
+                MessagingFactory.INTERNAL_THREAD_POOL
         );
     }
 

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
@@ -22,7 +22,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.microsoft.azure.servicebus.primitives.ClientConstants;
-import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
 import com.microsoft.azure.servicebus.primitives.CoreMessageReceiver;
 import com.microsoft.azure.servicebus.primitives.MessageWithDeliveryTag;
 import com.microsoft.azure.servicebus.primitives.MessageWithLockToken;

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
@@ -99,9 +99,9 @@ final class MessageSender extends InitializableEntity implements IMessageSender 
                         postSenderCreationFuture.completeExceptionally(cause);
                     }
                     return null;
-                });
+                }, MessagingFactory.INTERNAL_THREAD_POOL);
                 return postSenderCreationFuture;
-            });
+            }, MessagingFactory.INTERNAL_THREAD_POOL);
         }
     }
 
@@ -151,7 +151,7 @@ final class MessageSender extends InitializableEntity implements IMessageSender 
                 } else {
                     return CompletableFuture.completedFuture(null);
                 }
-            });
+            }, MessagingFactory.INTERNAL_THREAD_POOL);
         } else {
             return CompletableFuture.completedFuture(null);
         }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/QueueClient.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/QueueClient.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -201,24 +202,48 @@ public final class QueueClient extends InitializableEntity implements IQueueClie
         return this.queuePath;
     }
 
+    @Deprecated
     @Override
     public void registerMessageHandler(IMessageHandler handler) throws InterruptedException, ServiceBusException {
         this.messageAndSessionPump.registerMessageHandler(handler);
     }
 
+    @Deprecated
     @Override
     public void registerMessageHandler(IMessageHandler handler, MessageHandlerOptions handlerOptions) throws InterruptedException, ServiceBusException {
         this.messageAndSessionPump.registerMessageHandler(handler, handlerOptions);
     }
 
+    @Deprecated
     @Override
     public void registerSessionHandler(ISessionHandler handler) throws InterruptedException, ServiceBusException {
         this.messageAndSessionPump.registerSessionHandler(handler);
     }
 
+    @Deprecated
     @Override
     public void registerSessionHandler(ISessionHandler handler, SessionHandlerOptions handlerOptions) throws InterruptedException, ServiceBusException {
         this.messageAndSessionPump.registerSessionHandler(handler, handlerOptions);
+    }
+    
+    @Override
+    public void registerMessageHandler(IMessageHandler handler, ExecutorService executorService) throws InterruptedException, ServiceBusException {
+        this.messageAndSessionPump.registerMessageHandler(handler, executorService);
+    }
+
+    @Override
+    public void registerMessageHandler(IMessageHandler handler, MessageHandlerOptions handlerOptions, ExecutorService executorService) throws InterruptedException, ServiceBusException {
+        this.messageAndSessionPump.registerMessageHandler(handler, handlerOptions, executorService);
+    }
+
+    @Override
+    public void registerSessionHandler(ISessionHandler handler, ExecutorService executorService) throws InterruptedException, ServiceBusException {
+        this.messageAndSessionPump.registerSessionHandler(handler, executorService);
+    }
+
+    @Override
+    public void registerSessionHandler(ISessionHandler handler, SessionHandlerOptions handlerOptions, ExecutorService executorService) throws InterruptedException, ServiceBusException {
+        this.messageAndSessionPump.registerSessionHandler(handler, handlerOptions, executorService);
     }
 
     // No op now

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/SessionBrowser.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/SessionBrowser.java
@@ -59,7 +59,7 @@ final class SessionBrowser {
                     initFutures[initFutureIndex++] = browsableSession.initializeAsync();
                 }
                 CompletableFuture<Void> allInitFuture = CompletableFuture.allOf(initFutures);
-                return allInitFuture.thenComposeAsync((v) -> getMessageSessionsAsync(lastUpdatedTime, newLastReceivedSkip, newLastSessionId)).thenApply((c) -> {
+                return allInitFuture.thenComposeAsync((v) -> getMessageSessionsAsync(lastUpdatedTime, newLastReceivedSkip, newLastSessionId), MessagingFactory.INTERNAL_THREAD_POOL).thenApply((c) -> {
                     sessionsList.addAll(c);
                     return sessionsList;
                 });
@@ -67,6 +67,6 @@ final class SessionBrowser {
                 TRACE_LOGGER.debug("Got no browsable sessions from entity '{}'", this.entityPath);
                 return CompletableFuture.completedFuture(sessionsList);
             }
-        });
+        }, MessagingFactory.INTERNAL_THREAD_POOL);
     }
 }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/SubscriptionClient.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/SubscriptionClient.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
@@ -145,25 +146,49 @@ public final class SubscriptionClient extends InitializableEntity implements ISu
 		return this.miscRequestResponseHandler.getRulesAsync(skip, top);
 	}
 
+	@Deprecated
 	@Override
 	public void registerMessageHandler(IMessageHandler handler) throws InterruptedException, ServiceBusException {
 		this.messageAndSessionPump.registerMessageHandler(handler);		
 	}
 
+	@Deprecated
 	@Override
 	public void registerMessageHandler(IMessageHandler handler, MessageHandlerOptions handlerOptions) throws InterruptedException, ServiceBusException {
 		this.messageAndSessionPump.registerMessageHandler(handler, handlerOptions);		
 	}
 
+	@Deprecated
 	@Override
 	public void registerSessionHandler(ISessionHandler handler) throws InterruptedException, ServiceBusException {
 		this.messageAndSessionPump.registerSessionHandler(handler);		
 	}
 
+	@Deprecated
 	@Override
 	public void registerSessionHandler(ISessionHandler handler, SessionHandlerOptions handlerOptions) throws InterruptedException, ServiceBusException {
 		this.messageAndSessionPump.registerSessionHandler(handler, handlerOptions);		
 	}
+	
+	@Override
+    public void registerMessageHandler(IMessageHandler handler, ExecutorService executorService) throws InterruptedException, ServiceBusException {
+        this.messageAndSessionPump.registerMessageHandler(handler, executorService);
+    }
+
+    @Override
+    public void registerMessageHandler(IMessageHandler handler, MessageHandlerOptions handlerOptions, ExecutorService executorService) throws InterruptedException, ServiceBusException {
+        this.messageAndSessionPump.registerMessageHandler(handler, handlerOptions, executorService);
+    }
+
+    @Override
+    public void registerSessionHandler(ISessionHandler handler, ExecutorService executorService) throws InterruptedException, ServiceBusException {
+        this.messageAndSessionPump.registerSessionHandler(handler, executorService);
+    }
+
+    @Override
+    public void registerSessionHandler(ISessionHandler handler, SessionHandlerOptions handlerOptions, ExecutorService executorService) throws InterruptedException, ServiceBusException {
+        this.messageAndSessionPump.registerSessionHandler(handler, handlerOptions, executorService);
+    }
 
 	// No op now
 	@Override

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/SubscriptionClient.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/SubscriptionClient.java
@@ -48,7 +48,7 @@ public final class SubscriptionClient extends InitializableEntity implements ISu
 	{
 		this(receiveMode, amqpConnectionStringBuilder.getEntityPath());
 		CompletableFuture<MessagingFactory> factoryFuture = MessagingFactory.createFromConnectionStringBuilderAsync(amqpConnectionStringBuilder);
-		Utils.completeFuture(factoryFuture.thenComposeAsync((f) -> this.createPumpAndBrowserAsync(f)));
+		Utils.completeFuture(factoryFuture.thenComposeAsync((f) -> this.createPumpAndBrowserAsync(f), MessagingFactory.INTERNAL_THREAD_POOL));
 		if(TRACE_LOGGER.isInfoEnabled())
         {
             TRACE_LOGGER.info("Created subscription client to connection string '{}'", amqpConnectionStringBuilder.toLoggableString());
@@ -64,7 +64,7 @@ public final class SubscriptionClient extends InitializableEntity implements ISu
     {
         this(receiveMode, subscriptionPath);
         CompletableFuture<MessagingFactory> factoryFuture = MessagingFactory.createFromNamespaceEndpointURIAsyc(namespaceEndpointURI, clientSettings);
-        Utils.completeFuture(factoryFuture.thenComposeAsync((f) -> this.createPumpAndBrowserAsync(f)));
+        Utils.completeFuture(factoryFuture.thenComposeAsync((f) -> this.createPumpAndBrowserAsync(f), MessagingFactory.INTERNAL_THREAD_POOL));
         if (TRACE_LOGGER.isInfoEnabled()) {
             TRACE_LOGGER.info("Created subscription client to subscription '{}/{}'", namespaceEndpointURI.toString(), subscriptionPath);
         }
@@ -83,7 +83,7 @@ public final class SubscriptionClient extends InitializableEntity implements ISu
 		CompletableFuture<Void> postSessionBrowserFuture = MiscRequestResponseOperationHandler.create(factory, this.subscriptionPath, MessagingEntityType.SUBSCRIPTION).thenAcceptAsync((msoh) -> {
 			this.miscRequestResponseHandler = msoh;
 			this.sessionBrowser = new SessionBrowser(factory, this.subscriptionPath, MessagingEntityType.SUBSCRIPTION, msoh);
-		});		
+		}, MessagingFactory.INTERNAL_THREAD_POOL);		
 		
 		this.messageAndSessionPump = new MessageAndSessionPump(factory, this.subscriptionPath, MessagingEntityType.SUBSCRIPTION, receiveMode);
 		CompletableFuture<Void> messagePumpInitFuture = this.messageAndSessionPump.initializeAsync();

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientEntity.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientEntity.java
@@ -83,7 +83,7 @@ public abstract class ClientEntity
 					ClientEntity.this.isClosing = false;
 					ClientEntity.this.isClosed = true;
 				}
-			}});
+			}}, MessagingFactory.INTERNAL_THREAD_POOL);
 	}
 
 	public final void close() throws ServiceBusException

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CommonRequestResponseOperations.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CommonRequestResponseOperations.java
@@ -71,7 +71,7 @@ final class CommonRequestResponseOperations {
 				returningFuture.completeExceptionally(failureException);
 			}
 			return returningFuture;
-		});
+		}, MessagingFactory.INTERNAL_THREAD_POOL);
 	}
 	
 	static CompletableFuture<Void> sendCBSTokenAsync(RequestResponseLink requestResponseLink, Duration operationTimeout, SecurityToken securityToken)
@@ -98,6 +98,6 @@ final class CommonRequestResponseOperations {
                 returningFuture.completeExceptionally(failureException);
             }
             return returningFuture;
-        });
+        }, MessagingFactory.INTERNAL_THREAD_POOL);
 	}
 }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ConnectionStringBuilder.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ConnectionStringBuilder.java
@@ -10,8 +10,6 @@ import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.regex.*;
 
-import com.microsoft.azure.servicebus.security.SharedAccessSignatureTokenProvider;
-
 /**
  * This class can be used to construct a connection string which can establish communication with ServiceBus entities.
  * It can also be used to perform basic validation on an existing connection string.

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
@@ -164,7 +164,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 	                            exception = new TimeoutException("Request timed out.");
 	                        }
 	                        TRACE_LOGGER.error("UpdateState request timed out. Delivery:{}", entry.getKey(), exception);
-	                        entry.getValue().getWork().completeExceptionally(exception);
+	                        AsyncUtil.completeFutureExceptionally(entry.getValue().getWork(), exception);
 	                    }
 	                }
 			        TRACE_LOGGER.trace("'{}' core message receiver's internal loop to complete timed out update state requests stopped.", CoreMessageReceiver.this.receivePath);
@@ -295,7 +295,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
             {
                 Throwable cause = ExceptionUtil.extractAsyncCompletionCause(sasTokenEx);
                 TRACE_LOGGER.error("Sending SAS Token failed. ReceivePath:{}", this.receivePath, cause);
-                AsyncUtil.completeFutureExceptionally(this.linkOpen.getWork(), cause);
+                this.linkOpen.getWork().completeExceptionally(cause);
             }
             else
             {
@@ -313,12 +313,12 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
                 catch (IOException ioException)
                 {
                     this.cancelSASTokenRenewTimer();
-                    AsyncUtil.completeFutureExceptionally(this.linkOpen.getWork(), new ServiceBusException(false, "Failed to create Receiver, see cause for more details.", ioException));
+                    this.linkOpen.getWork().completeExceptionally(new ServiceBusException(false, "Failed to create Receiver, see cause for more details.", ioException));
                 }
             }
             
             return null;
-        });
+        }, MessagingFactory.INTERNAL_THREAD_POOL);
 		
 		return this.linkOpen.getWork();
 	}
@@ -347,7 +347,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
                         }
                     }
                     return null;
-                });
+                }, MessagingFactory.INTERNAL_THREAD_POOL);
             }
             
             return this.requestResponseLinkCreationFuture;
@@ -569,14 +569,14 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
                         {
                             CoreMessageReceiver.this.reduceCreditForCompletedReceiveRequest(receiveWorkItem.getMaxMessageCount());
                             TRACE_LOGGER.warn("No messages received from '{}'. Pending receive request timed out. Returning null to the client.", CoreMessageReceiver.this.receivePath);
-                            receiveWorkItem.getWork().complete(null);
+                            AsyncUtil.completeFuture(receiveWorkItem.getWork(), null);
                         }
                     }
                 },
                 timeout,
-                TimerType.OneTimeRun);
+                TimerType.OneTimeRun);        
         
-        this.ensureLinkIsOpen().thenRunAsync(() -> {this.addCredit(receiveWorkItem);});
+        this.ensureLinkIsOpen().thenRun(() -> {this.addCredit(receiveWorkItem);});
 		return onReceive;
 	}
 
@@ -896,8 +896,8 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 	            catch (IOException ioException)
 	            {
 	                this.pendingReceives.remove(receiveWorkItem);
-	                this.reduceCreditForCompletedReceiveRequest(receiveWorkItem.getMaxMessageCount());
-	                AsyncUtil.completeFutureExceptionally(receiveWorkItem.getWork(), generateDispatacherSchedulingFailedException("completeMessage", ioException));
+	                this.reduceCreditForCompletedReceiveRequest(receiveWorkItem.getMaxMessageCount());	                
+	                receiveWorkItem.getWork().completeExceptionally(generateDispatacherSchedulingFailedException("completeMessage", ioException));
 	                receiveWorkItem.cancelTimeoutTask(false);
 	            }
 	        }
@@ -931,7 +931,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 									String.format(Locale.US, "%s operation on ReceiveLink(%s) to path(%s) timed out at %s.", "Open", CoreMessageReceiver.this.receiveLink.getName(), CoreMessageReceiver.this.receivePath, ZonedDateTime.now()),
 									CoreMessageReceiver.this.lastKnownLinkError);
 							TRACE_LOGGER.warn(operationTimedout.getMessage());
-							ExceptionUtil.completeExceptionally(linkOpen.getWork(), operationTimedout, CoreMessageReceiver.this, false);
+							ExceptionUtil.completeExceptionally(linkOpen.getWork(), operationTimedout, CoreMessageReceiver.this, true);
 						}
 					}
 				}
@@ -952,7 +952,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 							Exception operationTimedout = new TimeoutException(String.format(Locale.US, "%s operation on Receive Link(%s) timed out at %s", "Close", CoreMessageReceiver.this.receiveLink.getName(), ZonedDateTime.now()));
 							TRACE_LOGGER.warn(operationTimedout.getMessage());
 
-							ExceptionUtil.completeExceptionally(linkClose, operationTimedout, CoreMessageReceiver.this, false);
+							ExceptionUtil.completeExceptionally(linkClose, operationTimedout, CoreMessageReceiver.this, true);
 						}
 					}
 				}
@@ -1123,14 +1123,14 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
         if(delivery == null)
         {
             TRACE_LOGGER.error("Delivery not found for delivery tag '{}'. Either receive link to '{}' closed with a transient error and reopened or the delivery was already settled by complete/abandon/defer/deadletter.", deliveryTagAsString, this.receivePath);
-            AsyncUtil.completeFutureExceptionally(completeMessageFuture, generateDeliveryNotFoundException());
+            completeMessageFuture.completeExceptionally(generateDeliveryNotFoundException());
         }
         else
         {
             final UpdateStateWorkItem workItem = new UpdateStateWorkItem(completeMessageFuture, outcome, CoreMessageReceiver.this.factoryRceiveTimeout);
             CoreMessageReceiver.this.pendingUpdateStateRequests.put(deliveryTagAsString, workItem);
             
-            CoreMessageReceiver.this.ensureLinkIsOpen().thenRunAsync(() -> {
+            CoreMessageReceiver.this.ensureLinkIsOpen().thenRun(() -> {
                 try
                 {
                     this.underlyingFactory.scheduleOnReactorThread(new DispatchHandler()
@@ -1173,7 +1173,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
                                         String.format(Locale.US, "%s operation on ReceiveLink(%s) to path(%s) timed out at %s.", "Open", CoreMessageReceiver.this.receiveLink.getName(), CoreMessageReceiver.this.receivePath, ZonedDateTime.now()));                           
                                 
                                 TRACE_LOGGER.warn(operationTimedout.getMessage());
-                                linkReopenFutureThatCanBeCancelled.completeExceptionally(operationTimedout);
+                                AsyncUtil.completeFutureExceptionally(linkReopenFutureThatCanBeCancelled, operationTimedout);
                             }
 	                    }
 	                    , CoreMessageReceiver.LINK_REOPEN_TIMEOUT
@@ -1205,7 +1205,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 	                    }
 	                }
 	                return null;
-	            });
+	            }, MessagingFactory.INTERNAL_THREAD_POOL);
 		    }
 		    
 		    return this.receiveLinkReopenFuture;
@@ -1312,8 +1312,8 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 					returningFuture.completeExceptionally(failureException);
 				}
 				return returningFuture;
-			});
-		});					
+			}, MessagingFactory.INTERNAL_THREAD_POOL);
+		}, MessagingFactory.INTERNAL_THREAD_POOL);					
 	}
 	
 	public CompletableFuture<Collection<MessageWithLockToken>> receiveDeferredMessageBatchAsync(Long[] sequenceNumbers)
@@ -1378,8 +1378,8 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 					returningFuture.completeExceptionally(failureException);
 				}
 				return returningFuture;
-			});
-		});		
+			}, MessagingFactory.INTERNAL_THREAD_POOL);
+		}, MessagingFactory.INTERNAL_THREAD_POOL);		
 	}
 	
 	public CompletableFuture<Void> updateDispositionAsync(UUID[] lockTokens, String dispositionStatus, String deadLetterReason, String deadLetterErrorDescription, Map<String, Object> propertiesToModify)
@@ -1435,8 +1435,8 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 					returningFuture.completeExceptionally(failureException);
 				}
 				return returningFuture;
-			});
-		});		
+			}, MessagingFactory.INTERNAL_THREAD_POOL);
+		}, MessagingFactory.INTERNAL_THREAD_POOL);		
 	}
 	
 	public CompletableFuture<Void> renewSessionLocksAsync()
@@ -1467,8 +1467,8 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 					returningFuture.completeExceptionally(failureException);
 				}
 				return returningFuture;
-			});
-		});		
+			}, MessagingFactory.INTERNAL_THREAD_POOL);
+		}, MessagingFactory.INTERNAL_THREAD_POOL);		
 	}
 	
 	public CompletableFuture<byte[]> getSessionStateAsync()
@@ -1508,8 +1508,8 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 					returningFuture.completeExceptionally(failureException);
 				}
 				return returningFuture;
-			});
-		});
+			}, MessagingFactory.INTERNAL_THREAD_POOL);
+		}, MessagingFactory.INTERNAL_THREAD_POOL);
 	}
 	
 	// NULL session state is allowed
@@ -1540,8 +1540,8 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 					returningFuture.completeExceptionally(failureException);
 				}
 				return returningFuture;
-			});
-		});		
+			}, MessagingFactory.INTERNAL_THREAD_POOL);
+		}, MessagingFactory.INTERNAL_THREAD_POOL);		
 	}
 	
 	// A receiver can be used to peek messages from any session-id, useful for browsable sessions
@@ -1550,6 +1550,6 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 	    this.throwIfInUnusableState();
 		return this.createRequestResponseLinkAsync().thenComposeAsync((v) -> {
 			return CommonRequestResponseOperations.peekMessagesAsync(this.requestResponseLink, this.operationTimeout, fromSequenceNumber, messageCount, sessionId, this.receiveLink.getName());
-		});
+		}, MessagingFactory.INTERNAL_THREAD_POOL);
 	}	
 }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageSender.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageSender.java
@@ -135,7 +135,7 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 		    }
 		    
 		    return null;
-        });
+        }, MessagingFactory.INTERNAL_THREAD_POOL);
 		
 		
 		return msgSender.linkFirstOpen;
@@ -165,7 +165,7 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
                         }
                     }
                     return null;
-                });
+                }, MessagingFactory.INTERNAL_THREAD_POOL);
             }
             
             return this.requestResponseLinkCreationFuture;
@@ -658,7 +658,7 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 									String.format(Locale.US, "Open operation on SendLink(%s) on Entity(%s) timed out at %s.",	CoreMessageSender.this.sendLink.getName(), CoreMessageSender.this.getSendPath(), ZonedDateTime.now().toString()),
 									CoreMessageSender.this.lastKnownErrorReportedAt.isAfter(Instant.now().minusSeconds(ClientConstants.SERVER_BUSY_BASE_SLEEP_TIME_IN_SECS)) ? CoreMessageSender.this.lastKnownLinkError : null);
 							TRACE_LOGGER.warn(operationTimedout.getMessage());
-							ExceptionUtil.completeExceptionally(CoreMessageSender.this.linkFirstOpen, operationTimedout, CoreMessageSender.this, false);
+							ExceptionUtil.completeExceptionally(CoreMessageSender.this.linkFirstOpen, operationTimedout, CoreMessageSender.this, true);
 						}
 					}
 				}
@@ -904,7 +904,7 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 							Exception operationTimedout = new TimeoutException(String.format(Locale.US, "%s operation on Send Link(%s) timed out at %s", "Close", CoreMessageSender.this.sendLink.getName(), ZonedDateTime.now()));							
 							TRACE_LOGGER.warn(operationTimedout.getMessage());
 
-							ExceptionUtil.completeExceptionally(linkClose, operationTimedout, CoreMessageSender.this, false);
+							ExceptionUtil.completeExceptionally(linkClose, operationTimedout, CoreMessageSender.this, true);
 						}
 					}
 				}
@@ -1056,8 +1056,8 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 					returningFuture.completeExceptionally(scheduleException);
 				}
 				return returningFuture;
-			});
-		});
+			}, MessagingFactory.INTERNAL_THREAD_POOL);
+		}, MessagingFactory.INTERNAL_THREAD_POOL);
 	}
 	
 	public CompletableFuture<Void> cancelScheduledMessageAsync(Long[] sequenceNumbers, Duration timeout)
@@ -1089,8 +1089,8 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 					returningFuture.completeExceptionally(failureException);
 				}
 				return returningFuture;
-			});
-		});
+			}, MessagingFactory.INTERNAL_THREAD_POOL);
+		}, MessagingFactory.INTERNAL_THREAD_POOL);
 	}
 	
 	// In case we need to support peek on a topic
@@ -1100,6 +1100,6 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 		return this.createRequestResponseLink().thenComposeAsync((v) ->
 		{
 			return CommonRequestResponseOperations.peekMessagesAsync(this.requestResponseLink, this.operationTimeout, fromSequenceNumber, messageCount, null, this.sendLink.getName());
-		});
+		}, MessagingFactory.INTERNAL_THREAD_POOL);
 	}
 }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
@@ -14,6 +14,8 @@ import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
@@ -48,6 +50,7 @@ import com.microsoft.azure.servicebus.security.SecurityToken;
 public class MessagingFactory extends ClientEntity implements IAmqpConnection
 {
     private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(MessagingFactory.class);
+    public static final ExecutorService INTERNAL_THREAD_POOL = Executors.newCachedThreadPool();
 	
     private static final String REACTOR_THREAD_NAME_PREFIX = "ReactorThread";
 	private static final int MAX_CBS_LINK_CREATION_ATTEMPTS = 3;

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MiscRequestResponseOperationHandler.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MiscRequestResponseOperationHandler.java
@@ -78,7 +78,7 @@ public final class MiscRequestResponseOperationHandler extends ClientEntity
                         }
                     }
                     return null;
-                });
+                }, MessagingFactory.INTERNAL_THREAD_POOL);
             }
             
             return this.requestResponseLinkCreationFuture;
@@ -139,8 +139,8 @@ public final class MiscRequestResponseOperationHandler extends ClientEntity
 					returningFuture.completeExceptionally(RequestResponseUtils.genereateExceptionFromResponse(responseMessage));
 				}
 				return returningFuture;
-			});
-		});
+			}, MessagingFactory.INTERNAL_THREAD_POOL);
+		}, MessagingFactory.INTERNAL_THREAD_POOL);
 	}
 	
 	public CompletableFuture<Void> removeRuleAsync(String ruleName)
@@ -167,8 +167,8 @@ public final class MiscRequestResponseOperationHandler extends ClientEntity
 					returningFuture.completeExceptionally(RequestResponseUtils.genereateExceptionFromResponse(responseMessage));
 				}
 				return returningFuture;
-			});
-		});
+			}, MessagingFactory.INTERNAL_THREAD_POOL);
+		}, MessagingFactory.INTERNAL_THREAD_POOL);
 	}
 	
 	public CompletableFuture<Void> addRuleAsync(RuleDescription ruleDescription)
@@ -196,8 +196,8 @@ public final class MiscRequestResponseOperationHandler extends ClientEntity
 					returningFuture.completeExceptionally(RequestResponseUtils.genereateExceptionFromResponse(responseMessage));
 				}
 				return returningFuture;
-			});
-		});		
+			}, MessagingFactory.INTERNAL_THREAD_POOL);
+		}, MessagingFactory.INTERNAL_THREAD_POOL);		
 	}
 
 	public CompletableFuture<Collection<RuleDescription>> getRulesAsync(int skip, int top)
@@ -243,7 +243,7 @@ public final class MiscRequestResponseOperationHandler extends ClientEntity
 				}
 
 				return returningFuture;
-			});
-		});
+			}, MessagingFactory.INTERNAL_THREAD_POOL);
+		}, MessagingFactory.INTERNAL_THREAD_POOL);
 	}
 }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
@@ -676,7 +676,7 @@ class RequestResponseLink extends ClientEntity{
 			
 		    // Return response in a separate thread so reactor thread is free to handle reactor events
 		    final Message finalResponseMessage = responseMessage;
-		    AsyncUtil.executorService.submit(() -> {
+		    MessagingFactory.INTERNAL_THREAD_POOL.submit(() -> {
 		        String requestMessageId = (String)finalResponseMessage.getCorrelationId();
 		        if(requestMessageId != null)
 	            {

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLinkCache.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLinkCache.java
@@ -123,7 +123,7 @@ class RequestResponseLinkcache
                 }
                 
                 return null;
-            });
+            }, MessagingFactory.INTERNAL_THREAD_POOL);
         }
         
         public CompletableFuture<RequestResponseLink> acquireReferenceAsync()

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/security/AzureActiveDirectoryTokenProvider.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/security/AzureActiveDirectoryTokenProvider.java
@@ -12,6 +12,7 @@ import com.microsoft.aad.adal4j.AuthenticationCallback;
 import com.microsoft.aad.adal4j.AuthenticationContext;
 import com.microsoft.aad.adal4j.AuthenticationResult;
 import com.microsoft.aad.adal4j.ClientCredential;
+import com.microsoft.azure.servicebus.primitives.MessagingFactory;
 
 /**
  * This is a token provider that obtains tokens from Azure Active Directory. It supports multiple modes of authentication with active directory
@@ -114,13 +115,13 @@ public class AzureActiveDirectoryTokenProvider extends TokenProvider
         @Override
         public void onFailure(Throwable authException) {
             TRACE_LOGGER.error("Getting token from Azure Active Directory failed", authException);
-            this.tokenGeneratingFutue.completeExceptionally(authException);
+            MessagingFactory.INTERNAL_THREAD_POOL.execute(() -> {this.tokenGeneratingFutue.completeExceptionally(authException);});
         }
 
         @Override
         public void onSuccess(AuthenticationResult authResult) {
             SecurityToken generatedToken = new SecurityToken(SecurityTokenType.JWT, this.audience, authResult.getAccessToken(), Instant.now(), Instant.now().plus(Duration.ofSeconds(authResult.getExpiresAfter())));
-            tokenGeneratingFutue.complete(generatedToken);
+            MessagingFactory.INTERNAL_THREAD_POOL.execute(() -> {tokenGeneratingFutue.complete(generatedToken);});
         }
         
     }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/security/ManagedServiceIdentityTokenProvider.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/security/ManagedServiceIdentityTokenProvider.java
@@ -9,12 +9,12 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ForkJoinPool;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
+import com.microsoft.azure.servicebus.primitives.MessagingFactory;
 
 /**
  * This is a token provider that obtains token using Managed Service Identity(MSI). This token provider automatically detects MSI settings.
@@ -38,7 +38,7 @@ public class ManagedServiceIdentityTokenProvider extends TokenProvider
     public CompletableFuture<SecurityToken> getSecurityTokenAsync(String audience) {
         String addAudienceForSB = SecurityConstants.SERVICEBUS_AAD_AUDIENCE_RESOURCE_URL;
         CompletableFuture<SecurityToken> tokenGeneratingFuture = new CompletableFuture<>();
-        ForkJoinPool.commonPool().execute(() -> {
+        MessagingFactory.INTERNAL_THREAD_POOL.execute(() -> {
             try
             {
                 MSIToken msiToken = getMSIToken(addAudienceForSB);

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/security/SharedAccessSignatureTokenProvider.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/security/SharedAccessSignatureTokenProvider.java
@@ -4,11 +4,11 @@ import java.security.InvalidKeyException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ForkJoinPool;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.microsoft.azure.servicebus.primitives.MessagingFactory;
 import com.microsoft.azure.servicebus.primitives.SASUtil;
 
 /**
@@ -61,7 +61,7 @@ public class SharedAccessSignatureTokenProvider extends TokenProvider
         else
         {
             CompletableFuture<SecurityToken> tokenGeneratingFuture = new CompletableFuture<>();
-            ForkJoinPool.commonPool().execute(() -> {
+            MessagingFactory.INTERNAL_THREAD_POOL.execute(() -> {
                 try {
                     String genereatedSASToken = SASUtil.generateSharedAccessSignatureToken(this.sasKeyName, this.sasKey, audience, this.tokenValidityInSeconds);
                     tokenGeneratingFuture.complete(new SecurityToken(SecurityTokenType.SAS, audience, genereatedSASToken, Instant.now(), Instant.now().plus(Duration.ofSeconds(this.tokenValidityInSeconds))));

--- a/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/ClientValidationTests.java
+++ b/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/ClientValidationTests.java
@@ -121,7 +121,7 @@ public class ClientValidationTests
 					@Override
 					public void notifyException(Throwable exception, ExceptionPhase phase) {					
 					}
-				});
+				}, MessageAndSessionPumpTests.EXECUTOR_SERVICE);
 				Assert.fail("QueueClient created to a subscription which shouldn't be allowed.");
 			}
 			finally
@@ -148,7 +148,7 @@ public class ClientValidationTests
 					@Override
 					public void notifyException(Throwable exception, ExceptionPhase phase) {					
 					}
-				});
+				}, MessageAndSessionPumpTests.EXECUTOR_SERVICE);
 				Assert.fail("SubscriptionClient created to a queue which shouldn't be allowed.");
 			} finally {
 				sc.close();
@@ -184,7 +184,7 @@ public class ClientValidationTests
 					public CompletableFuture<Void> OnCloseSessionAsync(IMessageSession session) {
 						return CompletableFuture.completedFuture(null);
 					}
-				});
+				}, MessageAndSessionPumpTests.EXECUTOR_SERVICE);
 				
 				Thread.sleep(1000); // Sleep for a second for the exception				
 				Assert.assertTrue("QueueClient created to a subscription which shouldn't be allowed.", unsupportedExceptionOccured.get());
@@ -222,7 +222,7 @@ public class ClientValidationTests
 					public CompletableFuture<Void> OnCloseSessionAsync(IMessageSession session) {
 						return CompletableFuture.completedFuture(null);
 					}
-				});
+				}, MessageAndSessionPumpTests.EXECUTOR_SERVICE);
 				
 				Thread.sleep(1000); // Sleep for a second for the exception				
 				Assert.assertTrue("SubscriptionClient created to a queue which shouldn't be allowed.", unsupportedExceptionOccured.get());

--- a/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/TestCommons.java
+++ b/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/TestCommons.java
@@ -21,8 +21,8 @@ import com.microsoft.azure.servicebus.primitives.StringUtil;
 
 public class TestCommons {
 	
-	private static final Duration SHORT_WAIT_TIME = Duration.ofSeconds(5);	
-	private static final Duration DRAIN_MESSAGES_WAIT_TIME = Duration.ofSeconds(5);
+	private static final Duration SHORT_WAIT_TIME = Duration.ofSeconds(2);
+	private static final Duration DRAIN_MESSAGES_WAIT_TIME = Duration.ofSeconds(2);
 	
 	public static void testBasicSend(IMessageSender sender) throws InterruptedException, ServiceBusException
 	{		

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<proton-j-version>0.22.0</proton-j-version>
 	  	<junit-version>4.12</junit-version>
 		<slf4j-version>1.7.0</slf4j-version>
-		<client-current-version>1.2.7</client-current-version>		
+		<client-current-version>1.2.8-SNAPSHOT</client-current-version>		
 	</properties>
 	
 	<modules>


### PR DESCRIPTION
1. SDK now creates a new cached thread pool and use it for all internal operations. Every handleAsync, thenRunAsync, thenApplyAsync, thenAcceptAsync, whenCompleteAsync call must pass this new thread pool as the second parameter. I have tried to change every such line in the code. Reviewers, double check it.
2. Added new APIs to QueueClient, TopicClient to accept a thread pool in registerHandler methods. All IMessageHandler, ISessionHandler methods are run on this passed thread pool. So if customer code is poorly written, other operations of the SDK won't be affected.
3. Also depreacted registerHandler methods that don't accept a thread pool. This is to nudge new developers to pass a thread pool. In applications that don't pass a thread pool (also existing customer code), IMessageHandler, ISessionHandler methods will run on ForkJoinPool.commonPool.
