### PR TITLE
Fixing a pseudo memory leak created by closing MessagingFactory befor…

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
@@ -615,36 +615,47 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
 	    }	    
 	}
 	
-	private CompletableFuture<Void> createCBSLinkAsync()
+	private void createCBSLinkAsync()
     {
+		if(this.getIsClosingOrClosed())
+		{
+			return;
+		}
+		
 	    if(++this.cbsLinkCreationAttempts > MAX_CBS_LINK_CREATION_ATTEMPTS )
 	    {
 	        Throwable completionEx = this.lastCBSLinkCreationException == null ? new Exception("CBS link creation failed multiple times.") : this.lastCBSLinkCreationException;
 	        this.cbsLinkCreationFuture.completeExceptionally(completionEx);
-	        return CompletableFuture.completedFuture(null);     
 	    }
 	    else
 	    {	        
 	        String requestResponseLinkPath = RequestResponseLink.getCBSNodeLinkPath();
 	        TRACE_LOGGER.info("Creating CBS link to {}", requestResponseLinkPath);
-	        CompletableFuture<Void> crateAndAssignRequestResponseLink =
-	                        RequestResponseLink.createAsync(this, this.getClientId() + "-cbs", requestResponseLinkPath, null, null).handleAsync((cbsLink, ex) ->
-	                        {
-	                            if(ex == null)
-	                            {
-	                                TRACE_LOGGER.info("Created CBS link to {}", requestResponseLinkPath);
-	                                this.cbsLink = cbsLink;	
-	                                this.cbsLinkCreationFuture.complete(null);
-	                            }
-	                            else
-	                            {
-	                                this.lastCBSLinkCreationException = ExceptionUtil.extractAsyncCompletionCause(ex);
-	                                TRACE_LOGGER.warn("Creating CBS link to {} failed. Attempts '{}'", requestResponseLinkPath, this.cbsLinkCreationAttempts);
-	                                this.createCBSLinkAsync();
-	                            }
-	                            return null;
-	                        }, MessagingFactory.INTERNAL_THREAD_POOL);       
-	        return crateAndAssignRequestResponseLink;
+	        RequestResponseLink.createAsync(this, this.getClientId() + "-cbs", requestResponseLinkPath, null, null).handleAsync((cbsLink, ex) ->
+            {
+                if(ex == null)
+                {
+                    TRACE_LOGGER.info("Created CBS link to {}", requestResponseLinkPath);
+                    if(this.getIsClosingOrClosed())
+                    {
+                    	// Factory is closed before CBSLink could be created. Close the created CBS link too
+                    	cbsLink.closeAsync();
+                    }
+                    else
+                    {
+                    	this.cbsLink = cbsLink;	
+                        this.cbsLinkCreationFuture.complete(null);
+                    }                    
+                }
+                else
+                {
+                    this.lastCBSLinkCreationException = ExceptionUtil.extractAsyncCompletionCause(ex);
+                    TRACE_LOGGER.warn("Creating CBS link to {} failed. Attempts '{}'", requestResponseLinkPath, this.cbsLinkCreationAttempts);
+                    this.createCBSLinkAsync();
+                }
+                return null;
+            }, MessagingFactory.INTERNAL_THREAD_POOL);
+	                        
 	    }	    
     }
 	

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLinkCache.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLinkCache.java
@@ -129,7 +129,6 @@ class RequestResponseLinkcache
             }, MessagingFactory.INTERNAL_THREAD_POOL);
         }
         
-        // Caller must acquire lock
         private void completeWaiters(Throwable exception)
         {
         	for(CompletableFuture<RequestResponseLink> waiter : this.waiters)


### PR DESCRIPTION
…e CBSLink could be created.

This is not a true leak because the RequestResponseLink has a finalize method and will eventually be freed.
But the finalize method may slow down the garbage collector and user will see increased memory consumption.
