### PR TITLE
Adding retry to RequestResponse link when idle connection is closed.

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
@@ -531,6 +531,11 @@ class MessageReceiver extends InitializableEntity implements IMessageReceiver, I
     public CompletableFuture<Collection<Instant>> renewMessageLockBatchAsync(Collection<? extends IMessage> messages) {
         this.ensurePeekLockReceiveMode();
 
+        if(messages == null || messages.size() == 0)
+        {
+        	throw new UnsupportedOperationException("Message collection is null or empty. Locks cannot be renewed.");
+        }
+        
         UUID[] lockTokens = new UUID[messages.size()];
         int messageIndex = 0;
         for (IMessage message : messages) {

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/AmqpErrorCode.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/AmqpErrorCode.java
@@ -24,4 +24,5 @@ public final class AmqpErrorCode
 
 	// connection errors
 	public static final Symbol ConnectionForced = Symbol.getSymbol("amqp:connection:forced");
+	public static final Symbol FramingError = Symbol.getSymbol("amqp:connection:framing-error");
 }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientConstants.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientConstants.java
@@ -49,7 +49,6 @@ public final class ClientConstants
 	public final static Symbol ENTITY_DISABLED_ERROR = Symbol.getSymbol(AmqpConstants.VENDOR + ":entity-disabled");
 	public final static Symbol PARTITION_NOT_OWNED_ERROR = Symbol.getSymbol(AmqpConstants.VENDOR + ":partition-not-owned");
 	public final static Symbol STORE_LOCK_LOST_ERROR = Symbol.getSymbol(AmqpConstants.VENDOR + ":store-lock-lost");
-	public final static Symbol PUBLISHER_REVOKED_ERROR = Symbol.getSymbol(AmqpConstants.VENDOR + ":publisher-revoked");
 	public final static Symbol TIMEOUT_ERROR = Symbol.getSymbol(AmqpConstants.VENDOR + ":timeout");
 	public final static Symbol LINK_TIMEOUT_PROPERTY = Symbol.getSymbol(AmqpConstants.VENDOR + ":timeout");
 	public final static Symbol LINK_PEEKMODE_PROPERTY = Symbol.getSymbol(AmqpConstants.VENDOR + ":peek-mode");

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientConstants.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientConstants.java
@@ -177,6 +177,7 @@ public final class ClientConstants
     
     static final int DEFAULT_SAS_TOKEN_SEND_RETRY_INTERVAL_IN_SECONDS = 5;
     static final String SAS_TOKEN_AUDIENCE_FORMAT = "amqp://%s/%s";
+    static final Duration SAS_TOKEN_SEND_TIMEOUT = Duration.ofSeconds(10);
 
     private static String getClientVersion() {
         String clientVersion;

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
@@ -430,7 +430,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
         else
         {            
             CompletableFuture<ScheduledFuture<?>> sendTokenFuture = this.underlyingFactory.sendSecurityTokenAndSetRenewTimer(this.sasTokenAudienceURI, retryOnFailure, () -> this.sendTokenAndSetRenewTimer(true));
-            return sendTokenFuture.thenAccept((f) -> {this.sasTokenRenewTimerFuture = f;TRACE_LOGGER.debug("Sent SAS Token and set renew timer");});
+            return sendTokenFuture.thenAccept((f) -> {this.sasTokenRenewTimerFuture = f;});
         }
     }
 	
@@ -575,7 +575,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
                     }
                 },
                 timeout,
-                TimerType.OneTimeRun);        
+                TimerType.OneTimeRun);
         
         this.ensureLinkIsOpen().thenRun(() -> {this.addCredit(receiveWorkItem);});
 		return onReceive;

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
@@ -93,7 +93,6 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 	private Receiver receiveLink;
 	private RequestResponseLink requestResponseLink;
 	private WorkItem<CoreMessageReceiver> linkOpen;
-	private Duration factoryRceiveTimeout;
 
 	private Exception lastKnownLinkError;
 	private Instant lastKnownErrorReportedAt;
@@ -132,7 +131,6 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 		this.prefetchedMessages = new ConcurrentLinkedQueue<MessageWithDeliveryTag>();
 		this.linkClose = new CompletableFuture<Void>();
 		this.lastKnownLinkError = null;
-		this.factoryRceiveTimeout = factory.getOperationTimeout();
 		this.prefetchCountSync = new Object();
 		this.retryPolicy = factory.getRetryPolicy();
 		this.pendingReceives = new ConcurrentLinkedQueue<ReceiveWorkItem>();
@@ -1111,7 +1109,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
         }
         else
         {
-            final UpdateStateWorkItem workItem = new UpdateStateWorkItem(completeMessageFuture, outcome, CoreMessageReceiver.this.factoryRceiveTimeout);
+            final UpdateStateWorkItem workItem = new UpdateStateWorkItem(completeMessageFuture, outcome, CoreMessageReceiver.this.operationTimeout);
             CoreMessageReceiver.this.pendingUpdateStateRequests.put(deliveryTagAsString, workItem);
             
             CoreMessageReceiver.this.ensureLinkIsOpen().thenRun(() -> {

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
@@ -793,12 +793,6 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 		}
 	}
 
-	public void onError(ErrorCondition error)
-	{		
-		Exception completionException = ExceptionUtil.toException(error);
-		this.onError(completionException);
-	}
-
 	@Override
 	public void onError(Exception exception)
 	{
@@ -970,7 +964,8 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 		}
 		else
 		{
-			this.onError(condition);
+			Exception completionException = ExceptionUtil.toException(condition);
+			this.onError(completionException);
 		}
 	}
 

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageSender.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageSender.java
@@ -623,16 +623,16 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
             return CompletableFuture.completedFuture(null);
         }
         else
-        {            
+        {
             CompletableFuture<ScheduledFuture<?>> sendTokenFuture = this.underlyingFactory.sendSecurityTokenAndSetRenewTimer(this.sasTokenAudienceURI, retryOnFailure, () -> this.sendTokenAndSetRenewTimer(true));
-            return sendTokenFuture.thenAccept((f) -> {this.sasTokenRenewTimerFuture = f; TRACE_LOGGER.debug("Sent SAS Token and set renew timer");});
+            return sendTokenFuture.thenAccept((f) -> {this.sasTokenRenewTimerFuture = f;});
         }
 	}
 	
 	private void cancelSASTokenRenewTimer()
     {
         if(this.sasTokenRenewTimerFuture != null && !this.sasTokenRenewTimerFuture.isDone())
-        {            
+        {
             this.sasTokenRenewTimerFuture.cancel(true);
             TRACE_LOGGER.debug("Cancelled SAS Token renew timer");
         }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageSender.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageSender.java
@@ -377,7 +377,6 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 	{
 		if (completionException == null)
 		{
-		    this.underlyingFactory.registerForConnectionError(this.sendLink);
 		    this.maxMessageSize = Util.getMaxMessageSizeFromLink(this.sendLink);
 			this.lastKnownLinkError = null;
 			this.retryPolicy.resetRetryCount(this.getClientId());
@@ -614,6 +613,7 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 		BaseHandler.setHandler(sender, handler);
 		sender.open();
 		this.sendLink = sender;
+		this.underlyingFactory.registerForConnectionError(this.sendLink);
 	}
 	
 	CompletableFuture<Void> sendTokenAndSetRenewTimer(boolean retryOnFailure)

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ExceptionUtil.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ExceptionUtil.java
@@ -89,6 +89,10 @@ public final class ExceptionUtil
 		{
 			return new ServiceBusException(true, new AmqpException(errorCondition));
 		}
+		else if (errorCondition.getCondition() == AmqpErrorCode.FramingError)
+		{
+			return new ServiceBusException(true, new AmqpException(errorCondition));
+		}
 		else if (errorCondition.getCondition() == AmqpErrorCode.ResourceLimitExceeded)
 		{
 			return new QuotaExceededException(errorCondition.getDescription());

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ExceptionUtil.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ExceptionUtil.java
@@ -83,7 +83,11 @@ public final class ExceptionUtil
 		}
 		else if (errorCondition.getCondition() == AmqpErrorCode.AmqpLinkDetachForced)
 		{
-			return new ServiceBusException(false, new AmqpException(errorCondition));
+			return new ServiceBusException(true, new AmqpException(errorCondition));
+		}
+		else if (errorCondition.getCondition() == AmqpErrorCode.ConnectionForced)
+		{
+			return new ServiceBusException(true, new AmqpException(errorCondition));
 		}
 		else if (errorCondition.getCondition() == AmqpErrorCode.ResourceLimitExceeded)
 		{

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
@@ -558,41 +558,73 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
 	
 	CompletableFuture<ScheduledFuture<?>> sendSecurityTokenAndSetRenewTimer(String sasTokenAudienceURI, boolean retryOnFailure, Runnable validityRenewer)
     {
+		CompletableFuture<ScheduledFuture<?>> result = new CompletableFuture<ScheduledFuture<?>>();
 	    TRACE_LOGGER.debug("Sending token for {}", sasTokenAudienceURI);
-	    CompletableFuture<SecurityToken> tokenFuture = this.clientSettings.getTokenProvider().getSecurityTokenAsync(sasTokenAudienceURI);
-	    return tokenFuture.thenComposeAsync((t) ->
-    	    {
-    	        SecurityToken generatedSecurityToken = t;
-    	        CompletableFuture<Void> sendTokenFuture = this.cbsLinkCreationFuture.thenComposeAsync((v) -> {
-    	                return CommonRequestResponseOperations.sendCBSTokenAsync(this.cbsLink, Util.adjustServerTimeout(this.clientSettings.getOperationTimeout()), generatedSecurityToken);
-    	            }, MessagingFactory.INTERNAL_THREAD_POOL);
-    	        
-    	        if(retryOnFailure)
-    	        {
-    	            return sendTokenFuture.handleAsync((v, sendTokenEx) -> {
-    	                if(sendTokenEx == null)
-    	                {
-    	                    TRACE_LOGGER.debug("Sent token for {}", sasTokenAudienceURI);
-    	                    return MessagingFactory.scheduleRenewTimer(generatedSecurityToken.getValidUntil(), validityRenewer);
-    	                }
-    	                else
-    	                {
-    	                    TRACE_LOGGER.warn("Sending CBS Token for {} failed.", sasTokenAudienceURI, sendTokenEx);
-    	                    TRACE_LOGGER.info("Will retry sending CBS Token for {} after {} seconds.", sasTokenAudienceURI, ClientConstants.DEFAULT_SAS_TOKEN_SEND_RETRY_INTERVAL_IN_SECONDS);
-    	                    return Timer.schedule(validityRenewer, Duration.ofSeconds(ClientConstants.DEFAULT_SAS_TOKEN_SEND_RETRY_INTERVAL_IN_SECONDS), TimerType.OneTimeRun);
-    	                }
-    	            }, MessagingFactory.INTERNAL_THREAD_POOL);
-    	        }
-    	        else
-    	        {
-    	            // Let the exception of the sendToken state pass up to caller
-    	            return sendTokenFuture.thenApply((v) -> {
-    	                TRACE_LOGGER.debug("Sent token for {}", sasTokenAudienceURI);
-    	                return MessagingFactory.scheduleRenewTimer(generatedSecurityToken.getValidUntil(), validityRenewer);
-    	            });
-    	        }
-    	    }, MessagingFactory.INTERNAL_THREAD_POOL);
+	    CompletableFuture<Instant> sendTokenFuture = this.generateAndSendSecurityToken(sasTokenAudienceURI);
+	    sendTokenFuture.handleAsync((validUntil, sendTokenEx) -> {
+            if(sendTokenEx == null)
+            {
+                TRACE_LOGGER.debug("Sent CBS token for {} and setting renew timer", sasTokenAudienceURI);
+                ScheduledFuture<?> renewalFuture = MessagingFactory.scheduleRenewTimer(validUntil, validityRenewer);
+                result.complete(renewalFuture);
+            }
+            else
+            {
+            	Throwable sendFailureCause = ExceptionUtil.extractAsyncCompletionCause(sendTokenEx);
+                TRACE_LOGGER.warn("Sending CBS Token for {} failed.", sasTokenAudienceURI, sendFailureCause);
+                if(retryOnFailure)
+                {
+                	// Just schedule another attempt
+                	TRACE_LOGGER.info("Will retry sending CBS Token for {} after {} seconds.", sasTokenAudienceURI, ClientConstants.DEFAULT_SAS_TOKEN_SEND_RETRY_INTERVAL_IN_SECONDS);
+                	ScheduledFuture<?> renewalFuture = Timer.schedule(validityRenewer, Duration.ofSeconds(ClientConstants.DEFAULT_SAS_TOKEN_SEND_RETRY_INTERVAL_IN_SECONDS), TimerType.OneTimeRun);
+                	result.complete(renewalFuture);
+                }
+                else
+                {
+                	if(sendFailureCause instanceof TimeoutException)
+                	{
+                		// Retry immediately on timeout. This is a special case as CBSLink may be disconnected right after the token is sent, but before it reaches the service
+                		TRACE_LOGGER.debug("Resending token for {}", sasTokenAudienceURI);
+                		CompletableFuture<Instant> resendTokenFuture = this.generateAndSendSecurityToken(sasTokenAudienceURI);
+                		resendTokenFuture.handleAsync((resendValidUntil, resendTokenEx) -> {
+                			if(resendTokenEx == null)
+                			{
+                				TRACE_LOGGER.debug("Sent CBS token for {} and setting renew timer", sasTokenAudienceURI);
+                                ScheduledFuture<?> renewalFuture = MessagingFactory.scheduleRenewTimer(resendValidUntil, validityRenewer);
+                                result.complete(renewalFuture);
+                			}
+                			else
+                			{
+                				Throwable resendFailureCause = ExceptionUtil.extractAsyncCompletionCause(resendTokenEx);
+                				TRACE_LOGGER.warn("Resending CBS Token for {} failed.", sasTokenAudienceURI, resendFailureCause);
+                				result.completeExceptionally(resendFailureCause);
+                			}
+                            return null;
+                		}, MessagingFactory.INTERNAL_THREAD_POOL);
+                	}
+                	else
+                	{
+                		result.completeExceptionally(sendFailureCause);
+                	}
+                }
+            }
+            return null;
+        }, MessagingFactory.INTERNAL_THREAD_POOL);
+	    
+	    return result;
     }
+	
+	private CompletableFuture<Instant> generateAndSendSecurityToken(String sasTokenAudienceURI)
+	{
+		CompletableFuture<SecurityToken> tokenFuture = this.clientSettings.getTokenProvider().getSecurityTokenAsync(sasTokenAudienceURI);
+		return tokenFuture.thenComposeAsync((t) ->
+	    {
+	        SecurityToken generatedSecurityToken = t;
+	        return this.cbsLinkCreationFuture.thenComposeAsync((v) -> {
+	                return CommonRequestResponseOperations.sendCBSTokenAsync(this.cbsLink, ClientConstants.SAS_TOKEN_SEND_TIMEOUT, generatedSecurityToken).thenApply((u) -> generatedSecurityToken.getValidUntil());
+	            }, MessagingFactory.INTERNAL_THREAD_POOL);
+	    }, MessagingFactory.INTERNAL_THREAD_POOL);
+	}
 	
 	private static ScheduledFuture<?> scheduleRenewTimer(Instant currentTokenValidUntil, Runnable validityRenewer)
 	{

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
@@ -178,7 +178,7 @@ class RequestResponseLink extends ClientEntity{
         else
         {
             CompletableFuture<ScheduledFuture<?>> sendTokenFuture = this.underlyingFactory.sendSecurityTokenAndSetRenewTimer(this.sasTokenAudienceURI, retryOnFailure, () -> this.sendTokenAndSetRenewTimer(true));
-            return sendTokenFuture.thenAccept((f) -> {this.sasTokenRenewTimerFuture = f; TRACE_LOGGER.debug("Set SAS Token renew timer");});
+            return sendTokenFuture.thenAccept((f) -> {this.sasTokenRenewTimerFuture = f;});
         }
     }
 	

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
@@ -409,13 +409,7 @@ class RequestResponseLink extends ClientEntity{
 	public CompletableFuture<Message> requestAysnc(Message requestMessage, Duration timeout)
 	{	    
 		this.throwIfClosed(null);
-		// Check and recreate links if necessary
-        if(!((this.amqpSender.sendLink.getLocalState() == EndpointState.ACTIVE && this.amqpSender.sendLink.getRemoteState() == EndpointState.ACTIVE)
-                && (this.amqpReceiver.receiveLink.getLocalState() == EndpointState.ACTIVE && this.amqpReceiver.receiveLink.getRemoteState() == EndpointState.ACTIVE)))
-        {
-            this.ensureUniqueLinkRecreation();
-        }
-        
+		
 		CompletableFuture<Message> responseFuture = new CompletableFuture<Message>();
 		RequestResponseWorkItem workItem = new RequestResponseWorkItem(requestMessage, responseFuture, timeout);
 		String requestId = "request:" +  this.requestCounter.incrementAndGet();
@@ -425,6 +419,14 @@ class RequestResponseLink extends ClientEntity{
 		workItem.setTimeoutTask(this.scheduleRequestTimeout(requestId, timeout));
 		TRACE_LOGGER.debug("Sending request with id:{}", requestId);
 		this.amqpSender.sendRequest(requestId, false);
+		
+		// Check and recreate links if necessary
+        if(!((this.amqpSender.sendLink.getLocalState() == EndpointState.ACTIVE && this.amqpSender.sendLink.getRemoteState() == EndpointState.ACTIVE)
+                && (this.amqpReceiver.receiveLink.getLocalState() == EndpointState.ACTIVE && this.amqpReceiver.receiveLink.getRemoteState() == EndpointState.ACTIVE)))
+        {
+            this.ensureUniqueLinkRecreation();
+        }
+        
 		return responseFuture;
 	}
 	
@@ -985,7 +987,7 @@ class RequestResponseLink extends ClientEntity{
                     else
                     {
                     	TRACE_LOGGER.warn("Request with id:{} not found in the requestresponse link.", requestIdToBeSent);
-                    }                    
+                    }
                 }
             }
             finally

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/Util.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/Util.java
@@ -442,7 +442,7 @@ public class Util
             return tokenValidityInSeconds - 10;
         }
         else
-        {            
+        {
             return (tokenValidityInSeconds - 1) > 0 ? tokenValidityInSeconds - 1 : 0;
         }
     }

--- a/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/TestCommons.java
+++ b/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/TestCommons.java
@@ -238,6 +238,7 @@ public class TestCommons {
 		if(isEntityPartitioned)
 		{
 			Assert.assertTrue("Messages not received", receivedMessages != null && receivedMessages.size() > 0);
+			totalReceivedMessages.addAll(receivedMessages);
 		}
 		else
 		{

--- a/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/TestCommons.java
+++ b/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/TestCommons.java
@@ -203,7 +203,7 @@ public class TestCommons {
 		
 	public static void testBasicReceiveAndRenewLockBatch(IMessageSender sender, String sessionId, IMessageReceiver receiver, boolean isEntityPartitioned) throws InterruptedException, ServiceBusException, ExecutionException
 	{		
-		int numMessages = 10;
+		int numMessages = 2;
 		if(isEntityPartitioned)
 		{
 			for(int i=0; i<numMessages; i++)
@@ -232,16 +232,17 @@ public class TestCommons {
 			sender.sendBatch(messages);
 		}
 				
-		ArrayList<IMessage> totalReceivedMessages = new ArrayList<>();		
+		ArrayList<IMessage> totalReceivedMessages = new ArrayList<>();
 		
-		Collection<IMessage> receivedMessages = receiver.receiveBatch(numMessages);
-		if(isEntityPartitioned)
+		if(isEntityPartitioned && sessionId == null)
 		{
+			Collection<IMessage> receivedMessages = receiver.receiveBatch(1);
 			Assert.assertTrue("Messages not received", receivedMessages != null && receivedMessages.size() > 0);
 			totalReceivedMessages.addAll(receivedMessages);
 		}
 		else
 		{
+			Collection<IMessage> receivedMessages = receiver.receiveBatch(numMessages);
 			while(receivedMessages != null && receivedMessages.size() > 0 && totalReceivedMessages.size() < numMessages)
 			{
 			    totalReceivedMessages.addAll(receivedMessages);


### PR DESCRIPTION
Adding retry to RequestResponse link when idle connection is closed. Otherwise CBS token sending will fail if a SEND request comes in right at the time of connection closing. Happened when a customer is sending 1 message every 15 minutes. Idle links are closed after 10 minutes, and another 5 minutes later connection is closed. Some of those sends were timing out as Req-Res link was not retrying on connection close.