### PR TITLE
Fixing a bug with frame size, that makes the SDK unable to receive large messages from partitioned entities.

### DIFF
--- a/azure-servicebus/pom.xml
+++ b/azure-servicebus/pom.xml
@@ -3,7 +3,7 @@
 	<description>Java library for Azure Service Bus</description>	
 	<modelVersion>4.0.0</modelVersion>		
 	<artifactId>azure-servicebus</artifactId>	
-	<version>2.0.0-PREVIEW-7</version>
+	<version>${client-current-version}</version>
 	<url>https://github.com/Azure/azure-service-bus-java</url>
 
 	<parent>

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/CustomIOHandler.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/CustomIOHandler.java
@@ -19,7 +19,6 @@ public class CustomIOHandler extends IOHandler
 		}
 
 		Transport transport = Proton.transport();
-		transport.setMaxFrameSize(AmqpConstants.WEBSOCKET_MAX_FRAME_SIZE);
 		transport.sasl();
 		transport.setEmitFlowEventOnSend(false);
 		transport.bind(connection);

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/WebSocketConnectionHandler.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/WebSocketConnectionHandler.java
@@ -51,6 +51,6 @@ public class WebSocketConnectionHandler extends ConnectionHandler {
     {
         // This is the current limitation of https://github.com/Azure/qpid-proton-j-extensions
         // once, this library enables larger frames - this property can be removed.
-        return 4 * 1024;
+        return AmqpConstants.WEBSOCKET_MAX_FRAME_SIZE;
     }
 }

--- a/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/QueueSendReceiveTests.java
+++ b/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/QueueSendReceiveTests.java
@@ -42,6 +42,10 @@ public class QueueSendReceiveTests extends SendReceiveTests
         String messageId = UUID.randomUUID().toString();
         Message message = new Message("AMQP message");
         message.setMessageId(messageId);
+        if(this.isEntityPartitioned())
+        {
+        	message.setPartitionKey(messageId);
+        }
         this.sender.send(message, transaction);
 
         this.factory.endTransactionAsync(transaction, true).get();
@@ -63,6 +67,10 @@ public class QueueSendReceiveTests extends SendReceiveTests
         String messageId = UUID.randomUUID().toString();
         Message message = new Message("AMQP message");
         message.setMessageId(messageId);
+        if(this.isEntityPartitioned())
+        {
+        	message.setPartitionKey(messageId);
+        }
         this.sender.send(message, transaction);
 
         this.factory.endTransactionAsync(transaction, false).get();
@@ -208,6 +216,10 @@ public class QueueSendReceiveTests extends SendReceiveTests
 
         TransactionContext transaction = this.factory.startTransactionAsync().get();
         this.receiver.complete(receivedMessage.getLockToken(), transaction);
+        if(this.isEntityPartitioned())
+        {
+        	message2.setPartitionKey(receivedMessage.getPartitionKey());
+        }
         this.sender.send(message2, transaction);
         this.factory.endTransactionAsync(transaction, true).get();
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<proton-j-version>0.29.0</proton-j-version>
 	  	<junit-version>4.12</junit-version>
 		<slf4j-version>1.7.0</slf4j-version>
-		<client-current-version>2.0.0-PREVIEW-7</client-current-version>
+		<client-current-version>2.0.0-PREVIEW-8-SNAPSHOT</client-current-version>
 		<qpid-proton-j-extensions-version>1.0.0</qpid-proton-j-extensions-version>
 	</properties>
 


### PR DESCRIPTION
Reactor sets the max frame size to 64 KB, but this bug was setting it to 4 KB at a later point. It is causing a frame reading error in reactor. Observed only with partitioned entities. I am also adding a test, but to the master branch. I will port that change later to the dev branch. Fixes #300 