### PR TITLE
Fix to verify hostname in the server certificate

### DIFF
--- a/azure-servicebus/pom.xml
+++ b/azure-servicebus/pom.xml
@@ -55,11 +55,6 @@
 	 	    <artifactId>proton-j</artifactId>
 	 	    <version>${proton-j-version}</version>
 	 	</dependency>
-	 	<dependency>
-	 	    <groupId>org.bouncycastle</groupId> 
-	 	    <artifactId>bcpkix-jdk15on</artifactId> 
-	 	    <version>1.53</version> 
-	  	</dependency>
 	  	<dependency>
 			 <groupId>com.microsoft.azure</groupId>
 			 <artifactId>adal4j</artifactId>

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageConverter.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageConverter.java
@@ -46,7 +46,9 @@ class MessageConverter
 		
 		if(brokeredMessage.getProperties() != null)
 		{
-			amqpMessage.setApplicationProperties(new ApplicationProperties(brokeredMessage.getProperties()));
+			Map<String, Object> applicationProperties = new HashMap<>();
+			applicationProperties.putAll(brokeredMessage.getProperties());
+			amqpMessage.setApplicationProperties(new ApplicationProperties(applicationProperties));
 		}
 		
 		if(brokeredMessage.getTimeToLive() != null)
@@ -134,7 +136,20 @@ class MessageConverter
 		ApplicationProperties applicationProperties = amqpMessage.getApplicationProperties();
 		if(applicationProperties != null)
 		{
-			brokeredMessage.setProperties(applicationProperties.getValue());
+			Map<String, String> convertedProperties = new HashMap<>();
+			for(Map.Entry<String, Object> entry : applicationProperties.getValue().entrySet())
+			{
+				if(entry.getValue() instanceof String)
+				{
+					convertedProperties.put(entry.getKey(), (String)entry.getValue());
+				}
+				else
+				{
+					convertedProperties.put(entry.getKey(), entry.getValue().toString());
+				}
+			}
+			
+			brokeredMessage.setProperties(convertedProperties);
 		}		
 		
 		// Header

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/ConnectionHandler.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/ConnectionHandler.java
@@ -41,6 +41,11 @@ public final class ConnectionHandler extends BaseHandler
 		this.messagingFactory = messagingFactory;
 	}
 	
+	public int getPort()
+	{
+		return ClientConstants.AMQPS_PORT;
+	}
+	
 	@Override
 	public void onConnectionInit(Event event)
 	{
@@ -78,7 +83,7 @@ public final class ConnectionHandler extends BaseHandler
 			SSLContext strictTlsContext = new StrictTLSContext(strictTlsContextSpi, defaultContext.getProvider(), defaultContext.getProtocol());
 			domain.setSslContext(strictTlsContext);
 			domain.setPeerAuthentication(SslDomain.VerifyMode.VERIFY_PEER_NAME);
-			SslPeerDetails peerDetails = Proton.sslPeerDetails(this.messagingFactory.getHostName(), this.messagingFactory.getPort());
+			SslPeerDetails peerDetails = Proton.sslPeerDetails(this.messagingFactory.getHostName(), this.getPort());
 			transport.ssl(domain, peerDetails);
 		} catch (NoSuchAlgorithmException e) {
 			// Should never happen

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/ConnectionHandler.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/ConnectionHandler.java
@@ -4,8 +4,11 @@
  */
 package com.microsoft.azure.servicebus.amqp;
 
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.net.ssl.SSLContext;
 
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.Symbol;
@@ -16,6 +19,7 @@ import org.apache.qpid.proton.engine.EndpointState;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.engine.Sasl;
 import org.apache.qpid.proton.engine.SslDomain;
+import org.apache.qpid.proton.engine.SslPeerDetails;
 import org.apache.qpid.proton.engine.Transport;
 import org.apache.qpid.proton.reactor.Handshaker;
 import org.slf4j.Logger;
@@ -58,14 +62,29 @@ public final class ConnectionHandler extends BaseHandler
 	@Override
 	public void onConnectionBound(Event event)
 	{
-	    TRACE_LOGGER.debug("onConnectionBound: hostname:{}", event.getConnection().getHostname());
+		TRACE_LOGGER.debug("onConnectionBound: hostname:{}", event.getConnection().getHostname());
 		Transport transport = event.getTransport();
-
-		SslDomain domain = makeDomain(SslDomain.Mode.CLIENT);
-		transport.ssl(domain);
-
+		
 		Sasl sasl = transport.sasl();
 		sasl.setMechanisms("ANONYMOUS");
+		
+		SslDomain domain = Proton.sslDomain();
+		domain.init(SslDomain.Mode.CLIENT);
+		
+		try {
+			// Default SSL context will have the root certificate from azure in truststore anyway
+			SSLContext defaultContext = SSLContext.getDefault();
+			StrictTLSContextSpi strictTlsContextSpi = new StrictTLSContextSpi(defaultContext);
+			SSLContext strictTlsContext = new StrictTLSContext(strictTlsContextSpi, defaultContext.getProvider(), defaultContext.getProtocol());
+			domain.setSslContext(strictTlsContext);
+			domain.setPeerAuthentication(SslDomain.VerifyMode.VERIFY_PEER_NAME);
+			SslPeerDetails peerDetails = Proton.sslPeerDetails(this.messagingFactory.getHostName(), this.messagingFactory.getPort());
+			transport.ssl(domain, peerDetails);
+		} catch (NoSuchAlgorithmException e) {
+			// Should never happen
+			TRACE_LOGGER.error("Default SSL algorithm not found in JRE. Please check your JRE setup.", e);
+//			this.messagingFactory.onConnectionError(new ErrorCondition(AmqpErrorCode.InternalError, e.getMessage()));
+		}
 	}
 
 	@Override
@@ -131,14 +150,4 @@ public final class ConnectionHandler extends BaseHandler
 	        connection.free();
 	    }
     }
-
-	private static SslDomain makeDomain(SslDomain.Mode mode)
-	{
-		SslDomain domain = Proton.sslDomain();
-		domain.init(mode);
-
-		// TODO: VERIFY_PEER_NAME support
-		domain.setPeerAuthentication(SslDomain.VerifyMode.ANONYMOUS_PEER);
-		return domain;
-	}
 }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/IAmqpConnection.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/IAmqpConnection.java
@@ -11,8 +11,6 @@ public interface IAmqpConnection
 {
 	String getHostName();
 	
-	int getPort();
-	
 	void onConnectionOpen();
 
 	void onConnectionError(ErrorCondition error);

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/IAmqpConnection.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/IAmqpConnection.java
@@ -9,6 +9,10 @@ import org.apache.qpid.proton.engine.Link;
 
 public interface IAmqpConnection
 {
+	String getHostName();
+	
+	int getPort();
+	
 	void onConnectionOpen();
 
 	void onConnectionError(ErrorCondition error);

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/StrictTLSContext.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/StrictTLSContext.java
@@ -1,0 +1,15 @@
+package com.microsoft.azure.servicebus.amqp;
+
+import java.security.Provider;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLContextSpi;
+
+// Customer SSLContext that wraps around an SSLContext and removes SSLv2Hello protocol from every SSLEngine created.
+public class StrictTLSContext extends SSLContext{
+	
+	protected StrictTLSContext(SSLContextSpi contextSpi, Provider provider, String protocol) {
+		super(contextSpi, provider, protocol);
+		// TODO Auto-generated constructor stub
+	}
+}

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/StrictTLSContext.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/StrictTLSContext.java
@@ -10,6 +10,5 @@ public class StrictTLSContext extends SSLContext{
 	
 	protected StrictTLSContext(SSLContextSpi contextSpi, Provider provider, String protocol) {
 		super(contextSpi, provider, protocol);
-		// TODO Auto-generated constructor stub
 	}
 }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/StrictTLSContextSpi.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/StrictTLSContextSpi.java
@@ -1,0 +1,94 @@
+package com.microsoft.azure.servicebus.amqp;
+
+import java.security.KeyManagementException;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLContextSpi;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+
+// Wraps over a standard SSL context and disables the SSLv2Hello protocol.
+public class StrictTLSContextSpi extends SSLContextSpi{
+
+	private static final String SSLv2Hello = "SSLv2Hello";
+	
+	SSLContext innerContext;
+	public StrictTLSContextSpi(SSLContext innerContext) {
+		this.innerContext = innerContext;
+	}
+	
+	@Override
+	protected SSLEngine engineCreateSSLEngine() {
+		SSLEngine engine = this.innerContext.createSSLEngine();
+		this.removeSSLv2Hello(engine);
+		return engine;
+	}
+
+	@Override
+	protected SSLEngine engineCreateSSLEngine(String arg0, int arg1) {
+		SSLEngine engine = this.innerContext.createSSLEngine(arg0, arg1);
+		this.removeSSLv2Hello(engine);
+		return engine;
+	}
+
+	@Override
+	protected SSLSessionContext engineGetClientSessionContext() {
+		return innerContext.getClientSessionContext();
+	}
+
+	@Override
+	protected SSLSessionContext engineGetServerSessionContext() {
+		return this.innerContext.getServerSessionContext();
+	}
+
+	@Override
+	protected SSLServerSocketFactory engineGetServerSocketFactory() {
+		return this.innerContext.getServerSocketFactory();
+	}
+
+	@Override
+	protected SSLSocketFactory engineGetSocketFactory() {
+		return this.innerContext.getSocketFactory();
+	}
+
+	@Override
+	protected void engineInit(KeyManager[] km, TrustManager[] tm, SecureRandom sr) throws KeyManagementException {
+		this.innerContext.init(km, tm, sr);		
+	}
+	
+	private void removeSSLv2Hello(SSLEngine engine)
+	{
+		String[] enabledProtocols = engine.getEnabledProtocols();
+		boolean sslv2HelloFound = false;
+		for(String protocol : enabledProtocols)
+		{
+			if(protocol.equalsIgnoreCase(SSLv2Hello))
+			{
+				sslv2HelloFound = true;
+				break;
+			}
+		}
+		
+		if(sslv2HelloFound)
+		{
+			ArrayList<String> modifiedProtocols = new ArrayList<String>();
+			for(String protocol : enabledProtocols)
+			{
+				if(!protocol.equalsIgnoreCase(SSLv2Hello))
+				{
+					modifiedProtocols.add(protocol);
+				}
+			}
+			
+			engine.setEnabledProtocols(modifiedProtocols.toArray(new String[modifiedProtocols.size()]));
+		}
+		
+		
+	}
+}

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
@@ -73,12 +73,10 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
 	private Throwable lastCBSLinkCreationException = null;
 	
 	private final ClientSettings clientSettings;
-	private final URI namespaceEndpointUri;
 	
 	private MessagingFactory(URI namespaceEndpointUri, ClientSettings clientSettings)
 	{
 	    super("MessagingFactory".concat(StringUtil.getShortRandomString()));
-	    this.namespaceEndpointUri = namespaceEndpointUri;
 	    this.clientSettings = clientSettings;
 	    
 	    this.hostName = namespaceEndpointUri.getHost();
@@ -98,7 +96,7 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
 
                 final Reactor r = e.getReactor();
                 TRACE_LOGGER.info("Creating connection to host '{}:{}'", hostName, ClientConstants.AMQPS_PORT);
-                connection = r.connectionToHost(hostName, ClientConstants.AMQPS_PORT, connectionHandler);
+                connection = r.connectionToHost(hostName, MessagingFactory.this.connectionHandler.getPort(), connectionHandler);
             }
         };
         Timer.register(this.getClientId());
@@ -108,12 +106,6 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
 	public String getHostName()
 	{
 		return this.hostName;
-	}
-	
-	@Override
-	public int getPort()
-	{
-		return ClientConstants.AMQPS_PORT;
 	}
 	
 	private Reactor getReactor()

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
@@ -104,9 +104,16 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
         Timer.register(this.getClientId());
 	}
 
-	String getHostName()
+	@Override
+	public String getHostName()
 	{
 		return this.hostName;
+	}
+	
+	@Override
+	public int getPort()
+	{
+		return ClientConstants.AMQPS_PORT;
 	}
 	
 	private Reactor getReactor()
@@ -145,7 +152,7 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
 	{
 		if (this.connection == null || this.connection.getLocalState() == EndpointState.CLOSED || this.connection.getRemoteState() == EndpointState.CLOSED)
 		{
-		    TRACE_LOGGER.info("Creating connection to host '{}:{}'", hostName, ClientConstants.AMQPS_PORT);
+		    TRACE_LOGGER.info("Creating connection to host '{}:{}'", this.hostName, ClientConstants.AMQPS_PORT);
 			this.connection = this.getReactor().connectionToHost(this.hostName, ClientConstants.AMQPS_PORT, this.connectionHandler);
 		}
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<url>https://github.com/Azure/azure-service-bus-java</url>
 	
 	<properties>
-		<proton-j-version>0.22.0</proton-j-version>
+		<proton-j-version>0.31.0</proton-j-version>
 	  	<junit-version>4.12</junit-version>
 		<slf4j-version>1.7.0</slf4j-version>
 		<client-current-version>1.2.9-SNAPSHOT</client-current-version>		


### PR DESCRIPTION
Upgraded to 0.31 version of ProtonJ.
Default java tls implementation sends a legacy handshake and it doesn't interoperate well with Windows TLS implementation, where AMQP protocol head of AzureServiceBus is hosted.
So added a minor tweak to work around the problem.