### PR TITLE
Making host name verification optional

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientConstants.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientConstants.java
@@ -175,6 +175,11 @@ public final class ClientConstants
     public static final UnsignedLong FALSE_FILTER_DESCRIPTOR = new UnsignedLong(0x000001370000008L);
     public static final UnsignedLong CORRELATION_FILTER_DESCRIPTOR = new UnsignedLong(0x000001370000009L);
     
+    public static final String SSL_VERIFY_MODE_PROPERTY_NAME = "com.microsoft.azure.servicebus.ssl.verifymode";
+    public static final String SSL_VERIFY_MODE_ANONYMOUS = "anonymous";
+    public static final String SSL_VERIFY_MODE_CERTONLY = "verifyCertificateOnly";
+    public static final String SSL_VERIFY_MODE_CERT_AND_HOSTNAME = "verifyCertificateAndHostName";
+    
     static final int DEFAULT_SAS_TOKEN_SEND_RETRY_INTERVAL_IN_SECONDS = 5;
     static final String SAS_TOKEN_AUDIENCE_FORMAT = "amqp://%s/%s";
     static final Duration SAS_TOKEN_SEND_TIMEOUT = Duration.ofSeconds(10);

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientConstants.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientConstants.java
@@ -176,9 +176,9 @@ public final class ClientConstants
     public static final UnsignedLong CORRELATION_FILTER_DESCRIPTOR = new UnsignedLong(0x000001370000009L);
     
     public static final String SSL_VERIFY_MODE_PROPERTY_NAME = "com.microsoft.azure.servicebus.ssl.verifymode";
-    public static final String SSL_VERIFY_MODE_ANONYMOUS = "anonymous";
-    public static final String SSL_VERIFY_MODE_CERTONLY = "verifyCertificateOnly";
-    public static final String SSL_VERIFY_MODE_CERT_AND_HOSTNAME = "verifyCertificateAndHostName";
+    public static final String SSL_VERIFY_MODE_ANONYMOUS = "anonymous"; // Accepts any certificate
+    public static final String SSL_VERIFY_MODE_CERTONLY = "verifyCertificateOnly"; // Accepts only certificates issued by trusted authorities
+    public static final String SSL_VERIFY_MODE_CERT_AND_HOSTNAME = "verifyCertificateAndHostName"; // Accepts only certificates  issued by trusted authorities and having same subject name as the host address
     
     static final int DEFAULT_SAS_TOKEN_SEND_RETRY_INTERVAL_IN_SECONDS = 5;
     static final String SAS_TOKEN_AUDIENCE_FORMAT = "amqp://%s/%s";

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<proton-j-version>0.31.0</proton-j-version>
 	  	<junit-version>4.12</junit-version>
 		<slf4j-version>1.7.0</slf4j-version>
-		<client-current-version>1.2.9</client-current-version>		
+		<client-current-version>1.2.10-SNAPSHOT</client-current-version>		
 	</properties>
 	
 	<modules>


### PR DESCRIPTION
For proxy or other ad-hoc scenarios, making TLS cert host name verification optional based on a system property. If no property specified, it defaults to host name verification. only those needing to bypass it will use the system property.