### PR TITLE
Fixing a regression caused by upgrading to proton-j version 1.31

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageConverter.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/MessageConverter.java
@@ -145,7 +145,14 @@ class MessageConverter
 				}
 				else
 				{
-					convertedProperties.put(entry.getKey(), entry.getValue().toString());
+					if(entry.getValue() == null)
+					{
+						convertedProperties.put(entry.getKey(), null);
+					}
+					else
+					{
+						convertedProperties.put(entry.getKey(), entry.getValue().toString());
+					}
 				}
 			}
 			

--- a/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/SendReceiveTests.java
+++ b/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/SendReceiveTests.java
@@ -153,6 +153,13 @@ public abstract class SendReceiveTests extends Tests {
 	}
 	
 	@Test
+	public void testBasicReceiveAndCompleteMessageWithProperties() throws InterruptedException, ServiceBusException, ExecutionException
+	{
+		this.receiver = ClientFactory.createMessageReceiverFromEntityPath(factory, this.receiveEntityPath, ReceiveMode.PEEKLOCK);
+		TestCommons.testBasicReceiveAndCompleteMessageWithProperties(this.sender, this.sessionId, this.receiver);
+	}
+	
+	@Test
 	public void testBasicReceiveAndAbandon() throws InterruptedException, ServiceBusException, ExecutionException
 	{
 		this.receiver = ClientFactory.createMessageReceiverFromEntityPath(factory, this.receiveEntityPath, ReceiveMode.PEEKLOCK);

--- a/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/SessionTests.java
+++ b/azure-servicebus/src/test/java/com/microsoft/azure/servicebus/SessionTests.java
@@ -164,6 +164,14 @@ public abstract class SessionTests extends Tests {
 	}
 	
 	@Test
+	public void testBasicReceiveAndCompleteMessageWithProperties() throws InterruptedException, ServiceBusException, ExecutionException
+	{
+		String sessionId = TestUtils.getRandomString();
+		this.session = ClientFactory.acceptSessionFromEntityPath(this.factory, this.receiveEntityPath, sessionId, ReceiveMode.PEEKLOCK);
+		TestCommons.testBasicReceiveAndCompleteMessageWithProperties(this.sender, sessionId, this.session);
+	}
+	
+	@Test
 	public void testBasicReceiveAndAbandon() throws InterruptedException, ServiceBusException, ExecutionException
 	{
 		String sessionId = TestUtils.getRandomString();


### PR DESCRIPTION
Fix addresses the case where a property value is null. Fixes #316 