### PR TITLE
Fixing the infinite loop renewing SAS token given in connection string

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CommonRequestResponseOperations.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CommonRequestResponseOperations.java
@@ -80,7 +80,6 @@ final class CommonRequestResponseOperations {
         Message requestMessage = RequestResponseUtils.createRequestMessageFromValueBody(ClientConstants.REQUEST_RESPONSE_PUT_TOKEN_OPERATION, securityToken.getTokenValue(), Util.adjustServerTimeout(operationTimeout));
         requestMessage.getApplicationProperties().getValue().put(ClientConstants.REQUEST_RESPONSE_PUT_TOKEN_TYPE, securityToken.getTokenType().toString());
         requestMessage.getApplicationProperties().getValue().put(ClientConstants.REQUEST_RESPONSE_PUT_TOKEN_AUDIENCE, securityToken.getTokenAudience());
-        requestMessage.getApplicationProperties().getValue().put(ClientConstants.REQUEST_RESPONSE_PUT_TOKEN_EXPIRATION, securityToken.getValidUntil().toEpochMilli());
         CompletableFuture<Message> responseFuture = requestResponseLink.requestAysnc(requestMessage, operationTimeout);
         return responseFuture.thenComposeAsync((responseMessage) -> {
             CompletableFuture<Void> returningFuture = new CompletableFuture<Void>();

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
@@ -1167,6 +1167,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 	                	Throwable cause = ExceptionUtil.extractAsyncCompletionCause(sendTokenEx);
         				TRACE_LOGGER.error("Sending SAS Token to '{}' failed.", this.receivePath, cause);
 	                    this.receiveLinkReopenFuture.completeExceptionally(sendTokenEx);
+	                    this.clearAllPendingWorkItems(sendTokenEx);
 	                }
 	                else
 	                {
@@ -1214,7 +1215,7 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 		this.pendingUpdateStateRequests.remove(deliveryTagAsString);
 	}
 	
-	private void clearAllPendingWorkItems(Exception exception)
+	private void clearAllPendingWorkItems(Throwable exception)
 	{
 	    TRACE_LOGGER.info("Completeing all pending receive and updateState operation on the receiver to '{}'", this.receivePath);
 		final boolean isTransientException = exception == null ||

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageSender.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageSender.java
@@ -553,7 +553,7 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 		}
 	}
 	
-	private void clearAllPendingSendsWithException(Exception failureException)
+	private void clearAllPendingSendsWithException(Throwable failureException)
 	{
 	    synchronized (this.pendingSendLock)
         {
@@ -567,7 +567,7 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
         }
 	}
 	
-	private void cleanupFailedSend(final SendWorkItem<Void> failedSend, final Exception exception)
+	private void cleanupFailedSend(final SendWorkItem<Void> failedSend, final Throwable exception)
 	{
 		failedSend.cancelTimeoutTask(false);		
 		ExceptionUtil.completeExceptionally(failedSend.getWork(), exception, this, true);
@@ -730,6 +730,7 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
                     	Throwable cause = ExceptionUtil.extractAsyncCompletionCause(sendTokenEx);
         				TRACE_LOGGER.error("Sending SAS Token to '{}' failed.", this.sendPath, cause);
                         this.sendLinkReopenFuture.completeExceptionally(sendTokenEx);
+                        this.clearAllPendingSendsWithException(sendTokenEx);
                     }
                     else
                     {

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ExceptionUtil.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ExceptionUtil.java
@@ -121,7 +121,7 @@ public final class ExceptionUtil
 		return new ServiceBusException(ClientConstants.DEFAULT_IS_TRANSIENT, errorCondition.toString());
 	}	
 
-	static <T> void completeExceptionally(CompletableFuture<T> future, Exception exception, IErrorContextProvider contextProvider, boolean completeAsynchronously)
+	static <T> void completeExceptionally(CompletableFuture<T> future, Throwable exception, IErrorContextProvider contextProvider, boolean completeAsynchronously)
 	{
 		if (exception != null && exception instanceof ServiceBusException)
 		{

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
@@ -627,9 +627,17 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
 	
 	private static ScheduledFuture<?> scheduleRenewTimer(Instant currentTokenValidUntil, Runnable validityRenewer)
 	{
-	    // It will eventually expire. Renew it
-        int renewInterval = Util.getTokenRenewIntervalInSeconds((int)Duration.between(Instant.now(), currentTokenValidUntil).getSeconds());
-        return Timer.schedule(validityRenewer, Duration.ofSeconds(renewInterval), TimerType.OneTimeRun);
+		if(currentTokenValidUntil == Instant.MAX)
+		{
+			// User provided token or will never expire
+			return null;
+		}
+		else
+		{
+			// It will eventually expire. Renew it
+	        int renewInterval = Util.getTokenRenewIntervalInSeconds((int)Duration.between(Instant.now(), currentTokenValidUntil).getSeconds());
+	        return Timer.schedule(validityRenewer, Duration.ofSeconds(renewInterval), TimerType.OneTimeRun);
+		}
 	}
 	
 	CompletableFuture<RequestResponseLink> obtainRequestResponseLinkAsync(String entityPath, MessagingEntityType entityType)

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
@@ -343,6 +343,7 @@ class RequestResponseLink extends ClientEntity{
                 Throwable cause = ExceptionUtil.extractAsyncCompletionCause(sasTokenEx);
                 TRACE_LOGGER.error("Sending SAS Token failed. RequestResponseLink path:{}", this.linkPath, cause);
                 recreateInternalLinksFuture.completeExceptionally(cause);
+                this.completeAllPendingRequestsWithException(cause);
             }
             else
             {
@@ -405,7 +406,7 @@ class RequestResponseLink extends ClientEntity{
 		return recreateInternalLinksFuture;
 	}
 	
-	private void completeAllPendingRequestsWithException(Exception exception)
+	private void completeAllPendingRequestsWithException(Throwable exception)
 	{
 	    TRACE_LOGGER.warn("Completing all pending requests with exception in request response link to {}", this.linkPath);
 		for(RequestResponseWorkItem workItem : this.pendingRequests.values())

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/Util.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/Util.java
@@ -425,7 +425,7 @@ public class Util
         }
         else
         {
-            tokenProvider = new SharedAccessSignatureTokenProvider(builder.getSharedAccessSignatureToken(), Instant.now().plus(Duration.ofSeconds(SecurityConstants.DEFAULT_SAS_TOKEN_VALIDITY_IN_SECONDS)));
+            tokenProvider = new SharedAccessSignatureTokenProvider(builder.getSharedAccessSignatureToken(), Instant.MAX); // Max validity as we will not generate another token
         }
         
         return new ClientSettings(tokenProvider, builder.getRetryPolicy(), builder.getOperationTimeout());


### PR DESCRIPTION
Fix for issue #338 
When a user uses a connection string with an already generated SAS token, the bug was assuming a validity of 20 minutes and at the end of 20 minutes, will run infinitely to send the token to the service.
Fixed by treating user provided SAS token as something that doesn't need refresh. This is how it was before we added support for AAD and TokenProvider model.