### PR TITLE
Fixing a minor memory leak.

### DIFF
--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/ConnectionHandler.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/ConnectionHandler.java
@@ -7,10 +7,7 @@ package com.microsoft.azure.servicebus.amqp;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.net.ssl.SSLContext;
-
-import com.microsoft.azure.servicebus.primitives.MessagingFactory;
 import com.microsoft.azure.servicebus.primitives.TransportType;
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.Symbol;
@@ -222,6 +219,11 @@ public class ConnectionHandler extends BaseHandler
 	@Override
     public void onConnectionFinal(Event event) {
 	    TRACE_LOGGER.debug("onConnectionFinal: hostname:{}", event.getConnection().getHostname());
+	    Connection connection = event.getConnection();
+	    if(connection != null)
+	    {
+	    	connection.attachments().clear();
+	    }
     }
 	
 	@Override

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/ReactorHandler.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/ReactorHandler.java
@@ -21,7 +21,7 @@ public class ReactorHandler extends BaseHandler
 	{		
 		TRACE_LOGGER.debug("reactor.onReactorInit");
 
-		final Reactor reactor = e.getReactor();
+		Reactor reactor = e.getReactor();
 		reactor.setTimeout(ClientConstants.REACTOR_IO_POLL_TIMEOUT);
 	}
 
@@ -29,5 +29,10 @@ public class ReactorHandler extends BaseHandler
 	public void onReactorFinal(Event e)
 	{		
 		TRACE_LOGGER.debug("reactor.onReactorFinal");
+		Reactor reactor = e.getReactor();
+		if(reactor != null)
+		{
+			reactor.attachments().clear();
+		}
 	}
 }

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/SessionHandler.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/SessionHandler.java
@@ -39,6 +39,11 @@ public class SessionHandler extends BaseHandler
 	public void onSessionLocalClose(Event e)
 	{		
 		TRACE_LOGGER.debug("onSessionLocalClose - entityName: {}, condition: {}", this.name, e.getSession().getCondition() == null ? "none" : e.getSession().getCondition().toString());
+		Session session = e.getSession();
+		if (session != null)
+		{
+			checkAndFreeSession(session);
+		}
 	}
 
 	@Override
@@ -47,9 +52,14 @@ public class SessionHandler extends BaseHandler
 		TRACE_LOGGER.debug("onSessionRemoteClose - entityName: {}, condition: {}", this.name, e.getSession().getCondition() == null ? "none" : e.getSession().getCondition().toString());
 
 		Session session = e.getSession();
-		if (session != null && session.getLocalState() != EndpointState.CLOSED)
+		if (session != null)
 		{
-			session.close();
+			if(session.getLocalState() != EndpointState.CLOSED)
+			{
+				session.close();
+			}
+			
+			checkAndFreeSession(session);
 		}
 	}
 
@@ -57,5 +67,18 @@ public class SessionHandler extends BaseHandler
 	public void onSessionFinal(Event e)
 	{ 
 	    TRACE_LOGGER.debug("onSessionFinal - entityName: {}", this.name);
+	    Session session = e.getSession();
+	    if(session != null)
+	    {
+	    	session.attachments().clear();
+	    }
+	}
+	
+	private static void checkAndFreeSession(Session session)
+	{
+		if(session.getLocalState() == EndpointState.CLOSED && session.getRemoteState() == EndpointState.CLOSED)
+		{
+			session.free();
+		}
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<proton-j-version>0.31.0</proton-j-version>
 	  	<junit-version>4.12</junit-version>
 		<slf4j-version>1.7.0</slf4j-version>
-		<client-current-version>2.0.0</client-current-version>
+		<client-current-version>2.0.1-SNAPSHOT</client-current-version>
 		<qpid-proton-j-extensions-version>1.0.0</qpid-proton-j-extensions-version>
 	</properties>
 


### PR DESCRIPTION
CoreMessageReceiver and CoreMessageSender objects are persisting in memory even after the corresponding senders and receivers are closed, until the messagingfactory is also closed. This manifests only when a client is using single messagingfactory to create many many senders or receivers.
One case in point is the case described in #350 where the customer is running a QueueClient session handler with no sessions in the queue. The queue client keeps trying to accept sessions, and these link creation requests will eventually time out. This cycle goes on, leaving many CoreMessageReceiver instances in memory until the QueueClient itself is closed. All told, the CoreMessageSender and CoreMessageReceiver objects are very small in memory and most customers wouldn't even notice an increase in memory.