### PR TITLE
Fixing a NullPointerException in RequestResponseLink

### DIFF
--- a/azure-servicebus/azure-servicebus.pom
+++ b/azure-servicebus/azure-servicebus.pom
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-servicebus</artifactId>
-    <version>1.2.13</version>
+    <version>1.2.14</version>
     <licenses>
         <license>
             <name>The MIT License (MIT)</name>

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
@@ -433,8 +433,8 @@ class RequestResponseLink extends ClientEntity{
 		this.amqpSender.sendRequest(requestId, false);
 		
 		// Check and recreate links if necessary
-        if(!((this.amqpSender.sendLink.getLocalState() == EndpointState.ACTIVE && this.amqpSender.sendLink.getRemoteState() == EndpointState.ACTIVE)
-                && (this.amqpReceiver.receiveLink.getLocalState() == EndpointState.ACTIVE && this.amqpReceiver.receiveLink.getRemoteState() == EndpointState.ACTIVE)))
+        if(!((this.amqpSender.sendLink != null && this.amqpSender.sendLink.getLocalState() == EndpointState.ACTIVE && this.amqpSender.sendLink.getRemoteState() == EndpointState.ACTIVE)
+                && (this.amqpReceiver.receiveLink != null && this.amqpReceiver.receiveLink.getLocalState() == EndpointState.ACTIVE && this.amqpReceiver.receiveLink.getRemoteState() == EndpointState.ACTIVE)))
         {
             this.ensureUniqueLinkRecreation();
         }

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<proton-j-version>0.31.0</proton-j-version>
 	  	<junit-version>4.12</junit-version>
 		<slf4j-version>1.7.0</slf4j-version>
-		<client-current-version>1.2.13</client-current-version>		
+		<client-current-version>1.2.14</client-current-version>		
 	</properties>
 	
 	<modules>


### PR DESCRIPTION
After a connection drop, there is a possibility that sendLink or ReceiveLink is still being created and NULL when a request is received.