### PR TITLE
Fixing a rare case of AuthorizationFailedException

### DIFF
--- a/azure-servicebus/azure-servicebus.pom
+++ b/azure-servicebus/azure-servicebus.pom
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-servicebus</artifactId>
-    <version>1.2.14</version>
+    <version>1.2.15</version>
     <licenses>
         <license>
             <name>The MIT License (MIT)</name>

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/MessagingFactory.java
@@ -140,7 +140,17 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
 		TRACE_LOGGER.info("Started reactor");
 	}
 	
-	Connection getConnection()
+	Connection getActiveConnectionOrNothing()
+	{
+		if (this.connection == null || this.connection.getLocalState() == EndpointState.CLOSED || this.connection.getRemoteState() == EndpointState.CLOSED) {
+			return null;
+		}
+		else {
+			return this.connection;
+		}
+	}
+	
+	Connection getActiveConnectionCreateIfNecessary()
 	{
 		if (this.connection == null || this.connection.getLocalState() == EndpointState.CLOSED || this.connection.getRemoteState() == EndpointState.CLOSED)
 		{
@@ -667,7 +677,7 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection
 	        this.cbsLinkCreationFuture.completeExceptionally(completionEx);
 	    }
 	    else
-	    {	        
+	    {
 	        String requestResponseLinkPath = RequestResponseLink.getCBSNodeLinkPath();
 	        TRACE_LOGGER.info("Creating CBS link to {}", requestResponseLinkPath);
 	        RequestResponseLink.createAsync(this, this.getClientId() + "-cbs", requestResponseLinkPath, null, null).handleAsync((cbsLink, ex) ->

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/RequestResponseLink.java
@@ -239,9 +239,27 @@ class RequestResponseLink extends ClientEntity{
 			commonLinkProperties.put(ClientConstants.ENTITY_TYPE_PROPERTY, this.entityType.getIntValue());
 		}
 		
-		// Create send link
-		final Connection connection = this.underlyingFactory.getConnection();
+		Connection connection;
+		if(this.sasTokenAudienceURI == null) {
+			// CBS link. Doesn't have to send SAS token
+			connection = this.underlyingFactory.getActiveConnectionCreateIfNecessary();
+		}
+		else {
+			connection = this.underlyingFactory.getActiveConnectionOrNothing();
+			if (connection == null) {
+				// Connection closed after sending CBS token. Happens only in the rare case of azure service bus closing idle connection, just right after sending
+				// CBS token but before opening a link.
+				TRACE_LOGGER.warn("Idle connection closed by service just after sending CBS token. Very rare case. Will retry.");
+				ServiceBusException exception = new ServiceBusException(true, "Idle connection closed by service just after sending CBS token. Please retry.");
+				AsyncUtil.completeFutureExceptionally(this.amqpSender.openFuture, exception);
+				AsyncUtil.completeFutureExceptionally(this.amqpReceiver.openFuture, exception);
+				// Retry with little delay so that link recreation in progress flag is reset
+				Timer.schedule(() -> {RequestResponseLink.this.ensureUniqueLinkRecreation();}, Duration.ofMillis(1000), TimerType.OneTimeRun);
+				return;
+			}
+		}
 
+		// Create send link
 		Session session = connection.session();
 		session.setOutgoingWindow(Integer.MAX_VALUE);
 		session.open();

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<proton-j-version>0.31.0</proton-j-version>
 	  	<junit-version>4.12</junit-version>
 		<slf4j-version>1.7.0</slf4j-version>
-		<client-current-version>1.2.14</client-current-version>		
+		<client-current-version>1.2.15</client-current-version>		
 	</properties>
 	
 	<modules>


### PR DESCRIPTION
Some customers use a cached QueueClient or MessageSender to send messages. If a client or sender remains idle for 15 minutes, the service closes the connection as idle connection. In some rare cases, the service closes the connection just when the client is trying to open a link on the same connection. If the connection is closed by service after CBS token is sent, link open operation was failing with AuthorizationFailed exception.