### PR TITLE
Fixing high CPU and memory leak in session pump 

### DIFF
--- a/azure-servicebus/azure-servicebus.pom
+++ b/azure-servicebus/azure-servicebus.pom
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-servicebus</artifactId>
-    <version>1.2.15</version>
+    <version>1.2.16</version>
     <licenses>
         <license>
             <name>The MIT License (MIT)</name>

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/ReceiveLinkHandler.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/amqp/ReceiveLinkHandler.java
@@ -60,7 +60,7 @@ public final class ReceiveLinkHandler extends BaseLinkHandler
 			}
 			else
 			{				
-				TRACE_LOGGER.debug("onLinkRemoteOpen: linkName:{}, remoteTarget:{}, remoteTarget:{}, action:{}", receiver.getName(), null, null, "waitingForError");
+				TRACE_LOGGER.debug("onLinkRemoteOpen: linkName:{}, remoteSource:{}, remoteTarget:{}, action:{}", receiver.getName(), null, null, "waitingForError");
 			}
 		}
 	}

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientEntity.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/ClientEntity.java
@@ -57,7 +57,18 @@ public abstract class ClientEntity
 	{
 		synchronized (this.syncClose)
 		{
+			this.isClosing = false;
 			this.isClosed = true;
+		}
+	}
+	
+	protected final void setClosing()
+	{
+		synchronized (this.syncClose)
+		{
+			if (!this.isClosed) {
+				this.isClosing = true;
+			}
 		}
 	}
 

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageReceiver.java
@@ -936,14 +936,15 @@ public class CoreMessageReceiver extends ClientEntity implements IAmqpReceiver, 
 					{
 						if (!linkOpen.getWork().isDone())
 						{
-						    CoreMessageReceiver.this.closeInternals(false);
-						    CoreMessageReceiver.this.setClosed();
-						    
 							Exception operationTimedout = new TimeoutException(
 									String.format(Locale.US, "%s operation on ReceiveLink(%s) to path(%s) timed out at %s.", "Open", CoreMessageReceiver.this.receiveLink.getName(), CoreMessageReceiver.this.receivePath, ZonedDateTime.now()),
 									CoreMessageReceiver.this.lastKnownLinkError);
 							TRACE_LOGGER.warn(operationTimedout.getMessage());
 							ExceptionUtil.completeExceptionally(linkOpen.getWork(), operationTimedout, CoreMessageReceiver.this, true);
+							
+							CoreMessageReceiver.this.setClosing();
+						    CoreMessageReceiver.this.closeInternals(false);
+						    CoreMessageReceiver.this.setClosed();
 						}
 					}
 				}

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageSender.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/CoreMessageSender.java
@@ -675,14 +675,15 @@ public class CoreMessageSender extends ClientEntity implements IAmqpSender, IErr
 					{
 						if (!CoreMessageSender.this.linkFirstOpen.isDone())
 						{
-						    CoreMessageSender.this.closeInternals(false);
-						    CoreMessageSender.this.setClosed();
-						    
 							Exception operationTimedout = new TimeoutException(
 									String.format(Locale.US, "Open operation on SendLink(%s) on Entity(%s) timed out at %s.",	CoreMessageSender.this.sendLink.getName(), CoreMessageSender.this.getSendPath(), ZonedDateTime.now().toString()),
 									CoreMessageSender.this.lastKnownErrorReportedAt.isAfter(Instant.now().minusSeconds(ClientConstants.SERVER_BUSY_BASE_SLEEP_TIME_IN_SECS)) ? CoreMessageSender.this.lastKnownLinkError : null);
 							TRACE_LOGGER.warn(operationTimedout.getMessage());
 							ExceptionUtil.completeExceptionally(CoreMessageSender.this.linkFirstOpen, operationTimedout, CoreMessageSender.this, true);
+							
+							CoreMessageSender.this.setClosing();
+						    CoreMessageSender.this.closeInternals(false);
+						    CoreMessageSender.this.setClosed();
 						}
 					}
 				}

--- a/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/Util.java
+++ b/azure-servicebus/src/main/java/com/microsoft/azure/servicebus/primitives/Util.java
@@ -385,7 +385,7 @@ public class Util
 	// Pass little less than client timeout to the server so client doesn't time out before server times out
 	static Duration adjustServerTimeout(Duration clientTimeout)
 	{
-		return clientTimeout.minusMillis(100);
+		return clientTimeout.minusMillis(200);
 	}
 	
 	// This is not super stable for some reason

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<proton-j-version>0.31.0</proton-j-version>
 	  	<junit-version>4.12</junit-version>
 		<slf4j-version>1.7.0</slf4j-version>
-		<client-current-version>1.2.15</client-current-version>		
+		<client-current-version>1.2.16</client-current-version>		
 	</properties>
 	
 	<modules>


### PR DESCRIPTION
Session  pump keeps trying to accept sessions and if a session is not available on the service, link creation will timeout. CoreMessageReceiver object is created, and then discarded as link creation fails. But the scheduled timer objects that are created in the constructor are not cancelled and after some time, there will too many timers taking CPU cycles and holding reference to CoreMessageRecevier objects preventing them from being garbage collected.