### PR TITLE
Fix the url of Api document in FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See our [Contribution Guidelines](./.github/CONTRIBUTING.md).
 
 ## FAQ
 ### Where is the API document?
-Click [here](https://docs.microsoft.com/en-us/java/api/overview/azure/servicebus/clientlibrary).
+Click [here](https://docs.microsoft.com/en-us/java/api/overview/azure/servicebus?view=azure-java-stable).
 
 ### Where can I find examples that use this library?
 


### PR DESCRIPTION
In the [README.md](https://github.com/Azure/azure-service-bus-java/blob/master1.0/README.md) the url of API document is wrong because a 404 page is returned.
I found the new url and I replaced the old one.

Old link: https://docs.microsoft.com/en-us/java/api/overview/azure/servicebus/clientlibrary
New link: https://docs.microsoft.com/en-us/java/api/overview/azure/servicebus?view=azure-java-stable
